### PR TITLE
chore: Add dropbear dependency for the ssh connection

### DIFF
--- a/recipes-core/images/cvm-initramfs.bbappend
+++ b/recipes-core/images/cvm-initramfs.bbappend
@@ -1,1 +1,1 @@
-PACKAGE_INSTALL:append = " searcher-ssh-key ssh-pubkey-server su-restriction disk-encryption"
+PACKAGE_INSTALL:append = " dropbear searcher-ssh-key ssh-pubkey-server su-restriction disk-encryption"

--- a/recipes-core/searcher-ssh-key/files/searcher-ssh-key.sh.in
+++ b/recipes-core/searcher-ssh-key/files/searcher-ssh-key.sh.in
@@ -9,8 +9,6 @@
 ### END INIT INFO
 
 start() {
-  # Start the attested TLS reverse proxy server
-  start_proxy
 
   echo "Starting searcher-ssh-key script"
   # Add searcher user


### PR DESCRIPTION
I am going to remove the dropbear package from the base TDX image by default and therefore since this is needed for the bob use-case, I am adding it here instead.

dropbear is not always necessary for each tdx based image and that's why we are removing it from the default builds