### PR TITLE
Re-architect Firewall

### DIFF
--- a/recipes-core/searcher-container/files/searcher-network-init
+++ b/recipes-core/searcher-container/files/searcher-network-init
@@ -60,60 +60,6 @@ CHAIN_MAINTENANCE_OUT="MAINTENANCE_OUT"
 CHAIN_PRODUCTION_IN="PRODUCTION_IN"
 CHAIN_PRODUCTION_OUT="PRODUCTION_OUT"
 
-# ###############################################################################
-# # Wait for other containers to be ready before starting the firewall
-# ###############################################################################
-# wait_for_container_ready() {
-#     echo "Waiting for '$CONTAINER_NAME' container to be ready..."
-#     max_attempts=10
-#     attempt=1
-    
-#     ssh_ipv4_ready=0
-#     ssh_ipv6_ready=0
-    
-#     while [ $attempt -le $max_attempts ]; do
-#         echo "Attempt $attempt/$max_attempts: Checking container status..."
-#         status=$(su -s /bin/sh searcher -c "$PODMAN container inspect --format '{{.State.Status}}' $CONTAINER_NAME" 2>/dev/null)
-#         if [ "$status" != "running" ]; then
-#             echo "Container status is '$status', waiting for 'running'"
-#             sleep 10
-#             attempt=$((attempt + 1))
-#             continue
-#         fi
-
-#         echo "Container status is 'running'"
-
-#         # Retrieve container logs
-#         su -s /bin/sh searcher -c "$PODMAN logs $CONTAINER_NAME 2>&1" > /tmp/container.log
-        
-#         # Detect SSH server readiness
-#         if grep -q "Server listening on 0.0.0.0 port 22" /tmp/container.log; then
-#             ssh_ipv4_ready=1
-#         fi
-#         if grep -q "Server listening on :: port 22" /tmp/container.log; then
-#             ssh_ipv6_ready=1
-#         fi
-
-#         echo "Container log readiness state:"
-#         echo " - IPv4 SSH server: $([[ $ssh_ipv4_ready -eq 1 ]] && echo 'Ready' || echo 'Waiting')"
-#         echo " - IPv6 SSH server: $([[ $ssh_ipv6_ready -eq 1 ]] && echo 'Ready' || echo 'Waiting')"
-
-#         if [ $ssh_ipv4_ready -eq 1 ] && [ $ssh_ipv6_ready -eq 1 ]; then
-#             echo "Container initialization complete."
-#             rm -f /tmp/container.log
-#             return 0
-#         fi
-        
-#         sleep 10
-#         attempt=$((attempt + 1))
-#     done
-
-#     echo "Container failed to become ready within timeout."
-#     rm -f /tmp/container.log
-#     return 1
-# }
-
-
 ###############################################################################
 # START FIREWALL
 ###############################################################################
@@ -304,10 +250,6 @@ stop_firewall() {
 ###############################################################################
 case "$1" in
     start)
-        # if ! wait_for_container_ready; then
-        #     echo "Error: Container not ready, cannot proceed with network setup."
-        #     exit 1
-        # fi
         start_firewall
         ;;
     stop)

--- a/recipes-core/searcher-container/files/searcher-network-init
+++ b/recipes-core/searcher-container/files/searcher-network-init
@@ -5,259 +5,317 @@
 # Required-Stop:     $network
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
-# Short-Description: Searcher Network Configuration
-# Description:       Sets up iptables rules for searcher container
+# Short-Description: Sets up iptables for maintenance/production with separate inbound/outbound chains
 ### END INIT INFO
 
-# Configuration variables
-PODMAN="/usr/bin/podman"
+###############################################################################
+# Binaries
+###############################################################################
 IPTABLES="/usr/sbin/iptables"
+IP6TABLES="/usr/sbin/ip6tables"
+CONNTRACK="/usr/sbin/conntrack"
+PODMAN="/usr/bin/podman"
 CONTAINER_NAME="searcher-container"
 
-# Port configurations
-SSH_CONTROL_PORT=22
-SSH_DATA_PORT=10022
-CL_P2P_PORT=9000
-EL_P2P_PORT=30303
-FB_STATE_DIFF_PORT=8547
-TITAN_STATE_DIFF_PORT=8548
-FB_RPC_PORT=8645
-TITAN_RPC_PORT=8646
-SEARCHER_INPUT_PORT_1=27017
-SEARCHER_INPUT_PORT_2=27018
-DNS_PORT=53
-HTTP_PORT=80
-HTTPS_PORT=443
+###############################################################################
+# Builder IP Addresses
+###############################################################################
+FLASHBOTS_BUILDER_IP="131.153.11.211"
+TITAN_BUILDER_IP="52.207.17.217"
 
-# Chain names for better organization and cleanup
-SEARCHER_INPUT="SEARCHER_INPUT"
-SEARCHER_OUTPUT="SEARCHER_OUTPUT"
-SEARCHER_MODE="SEARCHER_MODE"      # Mode-specific rules chain
-SEARCHER_BASE="SEARCHER_BASE"      # Permanent rules chain
-SEARCHER_BASE_ESTABLISHED="SEARCHER_BASE_ESTABLISHED" 
-SEARCHER_MODE_ESTABLISHED="SEARCHER_MODE_ESTABLISHED"  
+###############################################################################
+# Ports
+###############################################################################
+SSH_CONTROL_PORT=22        # Inbound: SSH control plane (always on)
+SSH_DATA_PORT=10022        # Inbound: SSH data plane (maintenance mode only)
 
-# make sure the container and openssh server is ready before we start setting up the restrictive firewall rules
-wait_for_container_ready() {
-    echo "Waiting for searcher container to be ready..."
-    max_attempts=10
-    attempt=1
+CL_P2P_PORT=9000           # TCP/UDP inbound/outbound: Consensus client P2P (always on)
+EL_P2P_PORT=30303          # TCP/UDP outbound: Execution client P2P (maintenance mode only)
+
+DNS_PORT=53                # Outbound: DNS (maintenance mode only)
+HTTP_PORT=80               # Outbound: HTTP (maintenance mode only)
+HTTPS_PORT=443             # Outbound: HTTPS (maintenance mode only)
+
+SEARCHER_INPUT_CHANNEL=27017  # Inbound: Input Only Channel (always on)
+
+FLASHBOTS_STATE_DIFF=8547        # Outbound: Flashbots builder state diff (production only)
+FLASHBOTS_BUNDLE_ENDPOINT=8645   # Outbound: Flashbots builder bundle submission (production only)
+TITAN_STATE_DIFF=42202           # Outbound: Titan builder state diff (production only)
+TITAN_BUNDLE_ENDPOINT=1337       # Outbound: Titan builder bundle submission (production only)
+
+CVM_REVERSE_PROXY_PORT=8745      # Inbound: CVM reverse proxy (always on)
+
+###############################################################################
+# Custom Chains
+###############################################################################
+CHAIN_ALWAYS_ON_IN="ALWAYS_ON_IN"
+CHAIN_ALWAYS_ON_OUT="ALWAYS_ON_OUT"
+
+CHAIN_MODE_SELECTOR_IN="MODE_SELECTOR_IN"
+CHAIN_MODE_SELECTOR_OUT="MODE_SELECTOR_OUT"
+
+CHAIN_MAINTENANCE_IN="MAINTENANCE_IN"
+CHAIN_MAINTENANCE_OUT="MAINTENANCE_OUT"
+
+CHAIN_PRODUCTION_IN="PRODUCTION_IN"
+CHAIN_PRODUCTION_OUT="PRODUCTION_OUT"
+
+# ###############################################################################
+# # Wait for other containers to be ready before starting the firewall
+# ###############################################################################
+# wait_for_container_ready() {
+#     echo "Waiting for '$CONTAINER_NAME' container to be ready..."
+#     max_attempts=10
+#     attempt=1
     
-    # Initialize flags
-    ssh_ipv4_ready=0
-    ssh_ipv6_ready=0
+#     ssh_ipv4_ready=0
+#     ssh_ipv6_ready=0
     
-    while [ $attempt -le $max_attempts ]; do
-        echo "Attempt $attempt/$max_attempts: Checking container status..."
-        status=$(su -s /bin/sh searcher -c "$PODMAN container inspect --format '{{.State.Status}}' $CONTAINER_NAME" 2>/dev/null)
-        if [ "$status" != "running" ]; then
-            echo "Container status is '$status', waiting for 'running'"
-            sleep 10
-            attempt=$((attempt + 1))
-            continue
-        fi
-        echo "Container status is 'running'"
+#     while [ $attempt -le $max_attempts ]; do
+#         echo "Attempt $attempt/$max_attempts: Checking container status..."
+#         status=$(su -s /bin/sh searcher -c "$PODMAN container inspect --format '{{.State.Status}}' $CONTAINER_NAME" 2>/dev/null)
+#         if [ "$status" != "running" ]; then
+#             echo "Container status is '$status', waiting for 'running'"
+#             sleep 10
+#             attempt=$((attempt + 1))
+#             continue
+#         fi
 
-        # Get logs into a file with both stdout and stderr
-        su -s /bin/sh searcher -c "$PODMAN logs $CONTAINER_NAME 2>&1" > /tmp/container.log
+#         echo "Container status is 'running'"
+
+#         # Retrieve container logs
+#         su -s /bin/sh searcher -c "$PODMAN logs $CONTAINER_NAME 2>&1" > /tmp/container.log
         
-        # Set flags based on grep results
-        if grep -q "Server listening on 0.0.0.0 port 22" /tmp/container.log; then
-            ssh_ipv4_ready=1
-        fi
+#         # Detect SSH server readiness
+#         if grep -q "Server listening on 0.0.0.0 port 22" /tmp/container.log; then
+#             ssh_ipv4_ready=1
+#         fi
+#         if grep -q "Server listening on :: port 22" /tmp/container.log; then
+#             ssh_ipv6_ready=1
+#         fi
+
+#         echo "Container log readiness state:"
+#         echo " - IPv4 SSH server: $([[ $ssh_ipv4_ready -eq 1 ]] && echo 'Ready' || echo 'Waiting')"
+#         echo " - IPv6 SSH server: $([[ $ssh_ipv6_ready -eq 1 ]] && echo 'Ready' || echo 'Waiting')"
+
+#         if [ $ssh_ipv4_ready -eq 1 ] && [ $ssh_ipv6_ready -eq 1 ]; then
+#             echo "Container initialization complete."
+#             rm -f /tmp/container.log
+#             return 0
+#         fi
         
-        if grep -q "Server listening on :: port 22" /tmp/container.log; then
-            ssh_ipv6_ready=1
-        fi
+#         sleep 10
+#         attempt=$((attempt + 1))
+#     done
 
-        echo "Current initialization state:"
-        echo "- IPv4 SSH server: $([[ $ssh_ipv4_ready -eq 1 ]] && echo "Ready" || echo "Waiting")"
-        echo "- IPv6 SSH server: $([[ $ssh_ipv6_ready -eq 1 ]] && echo "Ready" || echo "Waiting")"
+#     echo "Container failed to become ready within timeout."
+#     rm -f /tmp/container.log
+#     return 1
+# }
 
-        # If all required messages have been seen, container is ready
-        if [ $ssh_ipv4_ready -eq 1 ] && [ $ssh_ipv6_ready -eq 1 ]; then
-            echo "Container initialization complete"
-            rm -f /tmp/container.log
-            return 0
-        fi
-        
-        sleep 10
-        attempt=$((attempt + 1))
-    done
 
-    echo "Container failed to become ready within timeout"
-    rm -f /tmp/container.log
-    return 1
-}
+###############################################################################
+# START FIREWALL
+###############################################################################
+start_firewall() {
+    echo "Initializing firewall with separate inbound/outbound chains..."
 
-setup_base_rules() {
-    # Create custom chains
-    for chain in $SEARCHER_MODE $SEARCHER_BASE $SEARCHER_INPUT $SEARCHER_OUTPUT $SEARCHER_BASE_ESTABLISHED $SEARCHER_MODE_ESTABLISHED; do
-        $IPTABLES -N $chain 2>/dev/null || true
-        $IPTABLES -F $chain
-    done
-
-    # Link custom chains
-    # All incoming traffic is routed to the searcher input chain
-    $IPTABLES -A INPUT -j $SEARCHER_INPUT
-    # All outgoing traffic is routed to the searcher output chain
-    $IPTABLES -A OUTPUT -j $SEARCHER_OUTPUT
-
-    # Mode-specific rules are evaluated first
-    $IPTABLES -A $SEARCHER_INPUT -j $SEARCHER_MODE
-    $IPTABLES -A $SEARCHER_OUTPUT -j $SEARCHER_MODE
-
-    # Permanent rules are evaluated second
-    $IPTABLES -A $SEARCHER_INPUT -j $SEARCHER_BASE
-    $IPTABLES -A $SEARCHER_OUTPUT -j $SEARCHER_BASE
-    
-    # Split established connections into mode and base
-    # Mode-specific established connections are checked first
-    $IPTABLES -A INPUT -m state --state ESTABLISHED,RELATED -j $SEARCHER_MODE_ESTABLISHED
-    $IPTABLES -A OUTPUT -m state --state ESTABLISHED,RELATED -j $SEARCHER_MODE_ESTABLISHED
-    # Base established connections are checked second
-    $IPTABLES -A INPUT -m state --state ESTABLISHED,RELATED -j $SEARCHER_BASE_ESTABLISHED
-    $IPTABLES -A OUTPUT -m state --state ESTABLISHED,RELATED -j $SEARCHER_BASE_ESTABLISHED
-
-    # Default policy: DROP
+    ###########################################################################
+    # (1) Set default policies to DROP
+    ###########################################################################
     $IPTABLES -P INPUT DROP
     $IPTABLES -P FORWARD DROP
     $IPTABLES -P OUTPUT DROP
 
-    # Allow loopback
-    $IPTABLES -A INPUT -i lo -j ACCEPT
+    # TODO: IPv6 support and blocking
+    # $IP6TABLES -P INPUT DROP
+    # $IP6TABLES -P FORWARD DROP
+    # $IP6TABLES -P OUTPUT DROP
+
+    ###########################################################################
+    # (2) Flush any existing rules/chains
+    ###########################################################################
+    $IPTABLES -F
+    $IPTABLES -X
+
+    ###########################################################################
+    # (3) Create custom chains
+    ###########################################################################
+    for CHAIN in \
+        $CHAIN_ALWAYS_ON_IN $CHAIN_ALWAYS_ON_OUT \
+        $CHAIN_MODE_SELECTOR_IN $CHAIN_MODE_SELECTOR_OUT \
+        $CHAIN_MAINTENANCE_IN $CHAIN_MAINTENANCE_OUT \
+        $CHAIN_PRODUCTION_IN $CHAIN_PRODUCTION_OUT
+    do
+        $IPTABLES -N $CHAIN
+    done
+
+    ###########################################################################
+    # (4) Allow Established/Related connections (Inbound & Outbound)
+    # OUTPUT (always): SSH (22), CL P2P (9000), CVM reverse-proxy (8745)
+    # OUTPUT (maintenance): SSH (10022)
+    ###########################################################################
+    $IPTABLES -A INPUT  -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+    $IPTABLES -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+
+    ###########################################################################
+    # (5) Main Routing:
+    #     INPUT  -> ALWAYS_ON_IN -> MODE_SELECTOR_IN
+    #     OUTPUT -> ALWAYS_ON_OUT -> MODE_SELECTOR_OUT
+    ###########################################################################
+    $IPTABLES -A INPUT -j $CHAIN_ALWAYS_ON_IN
+    $IPTABLES -A INPUT -j $CHAIN_MODE_SELECTOR_IN
+
+    $IPTABLES -A OUTPUT -j $CHAIN_ALWAYS_ON_OUT
+    $IPTABLES -A OUTPUT -j $CHAIN_MODE_SELECTOR_OUT
+
+    ###########################################################################
+    # (6) ALWAYS_ON_IN: Inbound rules that never turn off
+    ###########################################################################
+    # SSH control port (22)
+    $IPTABLES -A $CHAIN_ALWAYS_ON_IN -p tcp --dport $SSH_CONTROL_PORT \
+        -m conntrack --ctstate NEW -j ACCEPT
+
+    # Searcher input channel (UDP on 27017)
+    $IPTABLES -A $CHAIN_ALWAYS_ON_IN -p udp --dport $SEARCHER_INPUT_CHANNEL \
+        -m conntrack --ctstate NEW -j ACCEPT
+
+    # Consensus (CL) P2P inbound on port 9000 (TCP + UDP)
+    $IPTABLES -A $CHAIN_ALWAYS_ON_IN -p tcp --dport $CL_P2P_PORT \
+        -m conntrack --ctstate NEW -j ACCEPT
+    $IPTABLES -A $CHAIN_ALWAYS_ON_IN -p udp --dport $CL_P2P_PORT \
+        -m conntrack --ctstate NEW -j ACCEPT
+
+    # CVM reverse-proxy inbound on port 8745 (TCP)
+    $IPTABLES -A $CHAIN_ALWAYS_ON_IN -p tcp --dport $CVM_REVERSE_PROXY_PORT \
+        -m conntrack --ctstate NEW -j ACCEPT
+
+    # Return from ALWAYS_ON_IN
+    $IPTABLES -A $CHAIN_ALWAYS_ON_IN -j RETURN
+
+    ###########################################################################
+    # (7) ALWAYS_ON_OUT: Outbound rules that never turn off
+    ###########################################################################
+    # CL P2P outbound on port 9000 (TCP + UDP)
+    $IPTABLES -A $CHAIN_ALWAYS_ON_OUT -p tcp --dport $CL_P2P_PORT \
+        -m conntrack --ctstate NEW -j ACCEPT
+    $IPTABLES -A $CHAIN_ALWAYS_ON_OUT -p udp --dport $CL_P2P_PORT \
+        -m conntrack --ctstate NEW -j ACCEPT
+
+    # Flashbots & Titan builder bundle endpoints (always on)
+    $IPTABLES -A $CHAIN_ALWAYS_ON_OUT -p tcp -d $FLASHBOTS_BUILDER_IP --dport $FLASHBOTS_BUNDLE_ENDPOINT \
+        -m conntrack --ctstate NEW -j ACCEPT
+    $IPTABLES -A $CHAIN_ALWAYS_ON_OUT -p tcp -d $TITAN_BUILDER_IP --dport $TITAN_BUNDLE_ENDPOINT \
+        -m conntrack --ctstate NEW -j ACCEPT
+
+    # Return from ALWAYS_ON_OUT
+    $IPTABLES -A $CHAIN_ALWAYS_ON_OUT -j RETURN
+
+    ###########################################################################
+    # (8) MAINTENANCE_IN: Inbound rules for Maintenance Mode
+    ###########################################################################
+    # SSH data plane on port 10022
+    $IPTABLES -A $CHAIN_MAINTENANCE_IN -p tcp --dport $SSH_DATA_PORT \
+        -m conntrack --ctstate NEW -j ACCEPT
+
+    # EL P2P inbound on port 30303 (TCP + UDP)
+    $IPTABLES -A $CHAIN_MAINTENANCE_IN -p tcp --dport $EL_P2P_PORT \
+        -m conntrack --ctstate NEW -j ACCEPT
+    $IPTABLES -A $CHAIN_MAINTENANCE_IN -p udp --dport $EL_P2P_PORT \
+        -m conntrack --ctstate NEW -j ACCEPT
+
+    # Return from MAINTENANCE_IN
+    $IPTABLES -A $CHAIN_MAINTENANCE_IN -j RETURN
+
+    ###########################################################################
+    # (9) MAINTENANCE_OUT: Outbound rules for Maintenance Mode
+    ###########################################################################
+    # DNS (UDP/TCP 53)
+    $IPTABLES -A $CHAIN_MAINTENANCE_OUT -p udp --dport $DNS_PORT \
+        -m conntrack --ctstate NEW -j ACCEPT
+    $IPTABLES -A $CHAIN_MAINTENANCE_OUT -p tcp --dport $DNS_PORT \
+        -m conntrack --ctstate NEW -j ACCEPT
+
+    # HTTP / HTTPS
+    $IPTABLES -A $CHAIN_MAINTENANCE_OUT -p tcp --dport $HTTP_PORT \
+        -m conntrack --ctstate NEW -j ACCEPT
+    $IPTABLES -A $CHAIN_MAINTENANCE_OUT -p tcp --dport $HTTPS_PORT \
+        -m conntrack --ctstate NEW -j ACCEPT
+
+    # EL P2P (30303) outbound only in Maintenance
+    $IPTABLES -A $CHAIN_MAINTENANCE_OUT -p tcp --dport $EL_P2P_PORT \
+        -m conntrack --ctstate NEW -j ACCEPT
+    $IPTABLES -A $CHAIN_MAINTENANCE_OUT -p udp --dport $EL_P2P_PORT \
+        -m conntrack --ctstate NEW -j ACCEPT
+
+    # Return from MAINTENANCE_OUT
+    $IPTABLES -A $CHAIN_MAINTENANCE_OUT -j RETURN
+
+    ###########################################################################
+    # (10) PRODUCTION_IN: Inbound rules for Production Mode
+    ###########################################################################
+    $IPTABLES -A $CHAIN_PRODUCTION_IN -j RETURN
+
+    ###########################################################################
+    # (11) PRODUCTION_OUT: Outbound rules for Production Mode
+    # IP whitelisted for builder IPs
+    ###########################################################################
+    # Flashbots state diff
+    $IPTABLES -A $CHAIN_PRODUCTION_OUT -p tcp -d $FLASHBOTS_BUILDER_IP --dport $FLASHBOTS_STATE_DIFF \
+        -m conntrack --ctstate NEW -j ACCEPT
+
+    # Titan state diff
+    $IPTABLES -A $CHAIN_PRODUCTION_OUT -p tcp -d $TITAN_BUILDER_IP --dport $TITAN_STATE_DIFF \
+        -m conntrack --ctstate NEW -j ACCEPT
+
+    # Return from PRODUCTION_OUT
+    $IPTABLES -A $CHAIN_PRODUCTION_OUT -j RETURN
+
+    ###########################################################################
+    # (12) Start in Maintenance Mode
+    ###########################################################################
+    $IPTABLES -A $CHAIN_MODE_SELECTOR_IN  -j $CHAIN_MAINTENANCE_IN
+    $IPTABLES -A $CHAIN_MODE_SELECTOR_OUT -j $CHAIN_MAINTENANCE_OUT
+
+    ###########################################################################
+    # (13) Allow loopback traffic
+    ###########################################################################
+    $IPTABLES -A INPUT  -i lo -j ACCEPT
     $IPTABLES -A OUTPUT -o lo -j ACCEPT
+
+    echo "Firewall initialized in Maintenance Mode."
 }
 
-setup_maintenance_rules() {
-    # Data Plane SSH (enabled in maintenance)
-    $IPTABLES -A $SEARCHER_MODE -p tcp --dport $SSH_DATA_PORT -j ACCEPT
-    $IPTABLES -A $SEARCHER_MODE_ESTABLISHED -p tcp --sport $SSH_DATA_PORT -m state --state ESTABLISHED -j ACCEPT
-
-    # Execution Client P2P
-    $IPTABLES -A $SEARCHER_MODE -p tcp --dport $EL_P2P_PORT -j ACCEPT
-    $IPTABLES -A $SEARCHER_MODE -p tcp --sport $EL_P2P_PORT -j ACCEPT
-    $IPTABLES -A $SEARCHER_MODE -p udp --dport $EL_P2P_PORT -j ACCEPT
-    $IPTABLES -A $SEARCHER_MODE -p udp --sport $EL_P2P_PORT -j ACCEPT
-    $IPTABLES -A $SEARCHER_MODE_ESTABLISHED -p tcp --sport $EL_P2P_PORT -m state --state ESTABLISHED -j ACCEPT
-    $IPTABLES -A $SEARCHER_MODE_ESTABLISHED -p tcp --dport $EL_P2P_PORT -m state --state ESTABLISHED -j ACCEPT
-    $IPTABLES -A $SEARCHER_MODE_ESTABLISHED -p udp --sport $EL_P2P_PORT -m state --state ESTABLISHED -j ACCEPT
-    $IPTABLES -A $SEARCHER_MODE_ESTABLISHED -p udp --dport $EL_P2P_PORT -m state --state ESTABLISHED -j ACCEPT
-
-    # Enable DNS access (both UDP and TCP)
-    # Inbound DNS
-    $IPTABLES -A $SEARCHER_MODE -p udp --dport $DNS_PORT -j ACCEPT
-    $IPTABLES -A $SEARCHER_MODE -p tcp --dport $DNS_PORT -j ACCEPT
-    $IPTABLES -A $SEARCHER_MODE_ESTABLISHED -p udp --sport $DNS_PORT -m state --state ESTABLISHED,RELATED -j ACCEPT
-    $IPTABLES -A $SEARCHER_MODE_ESTABLISHED -p tcp --sport $DNS_PORT -m state --state ESTABLISHED,RELATED -j ACCEPT
-    # Outbound DNS
-    $IPTABLES -A $SEARCHER_MODE -p udp --sport $DNS_PORT -j ACCEPT
-    $IPTABLES -A $SEARCHER_MODE -p tcp --sport $DNS_PORT -j ACCEPT
-    $IPTABLES -A $SEARCHER_MODE_ESTABLISHED -p udp --dport $DNS_PORT -m state --state ESTABLISHED,RELATED -j ACCEPT
-    $IPTABLES -A $SEARCHER_MODE_ESTABLISHED -p tcp --dport $DNS_PORT -m state --state ESTABLISHED,RELATED -j ACCEPT
-    
-    # Enable HTTPS access
-    # Inbound HTTPS
-    $IPTABLES -A $SEARCHER_MODE -p tcp --dport $HTTPS_PORT -j ACCEPT
-    $IPTABLES -A $SEARCHER_MODE_ESTABLISHED -p tcp --sport $HTTPS_PORT -m state --state ESTABLISHED,RELATED -j ACCEPT
-    # Outbound HTTPS
-    $IPTABLES -A $SEARCHER_MODE -p tcp --sport $HTTPS_PORT -j ACCEPT
-    $IPTABLES -A $SEARCHER_MODE_ESTABLISHED -p tcp --dport $HTTPS_PORT -m state --state ESTABLISHED,RELATED -j ACCEPT
-
-    # Enable HTTP access
-    # Inbound HTTP
-    $IPTABLES -A $SEARCHER_MODE -p tcp --dport $HTTP_PORT -j ACCEPT
-    $IPTABLES -A $SEARCHER_MODE_ESTABLISHED -p tcp --sport $HTTP_PORT -m state --state ESTABLISHED,RELATED -j ACCEPT
-    # Outbound HTTP
-    $IPTABLES -A $SEARCHER_MODE -p tcp --sport $HTTP_PORT -j ACCEPT
-    $IPTABLES -A $SEARCHER_MODE_ESTABLISHED -p tcp --dport $HTTP_PORT -m state --state ESTABLISHED,RELATED -j ACCEPT
-}
-
-# state diff is default blocked at startup
-setup_permanent_rules() {
-    # Control Plane SSH (always enabled)
-    $IPTABLES -A $SEARCHER_BASE -p tcp --dport $SSH_CONTROL_PORT -j ACCEPT
-    $IPTABLES -A $SEARCHER_BASE_ESTABLISHED -p tcp --sport $SSH_CONTROL_PORT -m state --state ESTABLISHED -j ACCEPT
-
-    # Consensus Client P2P
-    $IPTABLES -A $SEARCHER_BASE -p tcp --dport $CL_P2P_PORT -j ACCEPT
-    $IPTABLES -A $SEARCHER_BASE -p tcp --sport $CL_P2P_PORT -j ACCEPT
-    $IPTABLES -A $SEARCHER_BASE -p udp --dport $CL_P2P_PORT -j ACCEPT
-    $IPTABLES -A $SEARCHER_BASE -p udp --sport $CL_P2P_PORT -j ACCEPT
-    $IPTABLES -A $SEARCHER_BASE_ESTABLISHED -p tcp --sport $CL_P2P_PORT -m state --state ESTABLISHED -j ACCEPT
-    $IPTABLES -A $SEARCHER_BASE_ESTABLISHED -p tcp --dport $CL_P2P_PORT -m state --state ESTABLISHED -j ACCEPT
-    $IPTABLES -A $SEARCHER_BASE_ESTABLISHED -p udp --sport $CL_P2P_PORT -m state --state ESTABLISHED -j ACCEPT
-    $IPTABLES -A $SEARCHER_BASE_ESTABLISHED -p udp --dport $CL_P2P_PORT -m state --state ESTABLISHED -j ACCEPT
-
-    # RPC Bundle Submission Chain:
-    # Container(8545) -> Host(8555) -> Destination(8565)
-    # Container internal port: 8545 (which is mapped to host 8555 in the podman config)
-    # RPC Bundle Submission Chain (outbound only)
-    # Allow outgoing connections to destination port 8565
-    # PING rpc.flashbots.net (172.67.36.8) 56(84) bytes of data.
-    $IPTABLES -A $SEARCHER_BASE -p tcp -d 172.67.36.8 --dport 443 -j ACCEPT
-    $IPTABLES -A $SEARCHER_BASE_ESTABLISHED -p tcp -s 172.67.36.8 --sport 443 -m state --state ESTABLISHED -j ACCEPT
-
-    # Searcher Input Channels (UDP)
-    $IPTABLES -A $SEARCHER_BASE -p udp --dport $SEARCHER_INPUT_PORT_1 -j ACCEPT
-    $IPTABLES -A $SEARCHER_BASE -p udp --dport $SEARCHER_INPUT_PORT_2 -j ACCEPT
-}
-
-cleanup_rules() {
-    # Remove custom chains from main chains
-    $IPTABLES -D INPUT -j $SEARCHER_INPUT 2>/dev/null || true
-    $IPTABLES -D OUTPUT -j $SEARCHER_OUTPUT 2>/dev/null || true
-    $IPTABLES -D INPUT -m state --state ESTABLISHED,RELATED -j $SEARCHER_MODE_ESTABLISHED 2>/dev/null || true
-    $IPTABLES -D OUTPUT -m state --state ESTABLISHED,RELATED -j $SEARCHER_MODE_ESTABLISHED 2>/dev/null || true
-    $IPTABLES -D INPUT -m state --state ESTABLISHED,RELATED -j $SEARCHER_BASE_ESTABLISHED 2>/dev/null || true
-    $IPTABLES -D OUTPUT -m state --state ESTABLISHED,RELATED -j $SEARCHER_BASE_ESTABLISHED 2>/dev/null || true
-
-    # Flush and delete custom chains
-    for chain in $SEARCHER_MODE $SEARCHER_BASE $SEARCHER_INPUT $SEARCHER_OUTPUT $SEARCHER_BASE_ESTABLISHED $SEARCHER_MODE_ESTABLISHED; do
-        $IPTABLES -F $chain 2>/dev/null || true
-        $IPTABLES -X $chain 2>/dev/null || true
-    done
-
-    # Reset default policies
+###############################################################################
+# STOP FIREWALL
+###############################################################################
+stop_firewall() {
+    echo "Flushing all firewall rules..."
+    $IPTABLES -F
+    $IPTABLES -X
     $IPTABLES -P INPUT DROP
     $IPTABLES -P FORWARD DROP
     $IPTABLES -P OUTPUT DROP
+    echo "Firewall stopped (default DROP)."
 }
 
+###############################################################################
+# MAIN HANDLER
+###############################################################################
 case "$1" in
     start)
-        if ! wait_for_container_ready; then
-            echo "Container is not ready, cannot proceed with network setup"
-            exit 1
-        fi
-
-        echo "Setting up searcher network rules..."
-        if setup_base_rules && setup_maintenance_rules && setup_permanent_rules; then
-            echo "Network setup completed successfully"
-            exit 0
-        else
-            echo "Failed to setup network rules"
-            exit 1
-        fi
+        # if ! wait_for_container_ready; then
+        #     echo "Error: Container not ready, cannot proceed with network setup."
+        #     exit 1
+        # fi
+        start_firewall
         ;;
     stop)
-        echo "Cleaning up searcher network rules..."
-        if cleanup_rules; then
-            echo "Network rules cleanup completed successfully"
-            exit 0
-        else
-            echo "Failed to cleanup network rules"
-            exit 1
-        fi
+        stop_firewall
         ;;
     status)
-        echo "Current iptables rules:"
-        $IPTABLES -L -v -n
-        echo "\nCustom chains:"
-        $IPTABLES -L $SEARCHER_INPUT -v -n
-        $IPTABLES -L $SEARCHER_OUTPUT -v -n
-        $IPTABLES -L $SEARCHER_MODE_ESTABLISHED -v -n
-        $IPTABLES -L $SEARCHER_BASE_ESTABLISHED -v -n
+        echo "=== iptables -L -n -v ==="
+        $IPTABLES -L -n -v
         ;;
     *)
         echo "Usage: $0 {start|stop|status}"

--- a/recipes-core/searcher-container/files/searcher-pod-init
+++ b/recipes-core/searcher-container/files/searcher-pod-init
@@ -12,33 +12,24 @@
 DAEMON=/usr/bin/podman
 USER=searcher
 NAME=searcher-container
+
+# PORT FORWARDS
 SEARCHER_SSH_PORT=10022
-FB_STATE_DIFF_PORT=8547
-TITAN_STATE_DIFF_PORT=8548
-FB_RPC_PORT=10000 # temp since our http server is on 8645
-TITAN_RPC_PORT=8646
-EL_P2P_PORT=30303
 ENGINE_API_PORT=8551
-SEARCHER_INPUT_PORT_1=27017
-SEARCHER_INPUT_PORT_2=27018
-IPTABLES="/usr/sbin/iptables"
+EL_P2P_PORT=30303
 
 case "$1" in
     start)
 
         mkdir -p /etc/searcher/ssh_hostkey
         chown searcher:searcher /etc/searcher/ssh_hostkey   
-        
+
         echo "Starting $NAME..."
         su -s /bin/sh $USER -c "cd ~ && $DAEMON run -d \
             --name $NAME \
             -p ${SEARCHER_SSH_PORT}:22 \
-            -p ${FB_STATE_DIFF_PORT}:${FB_STATE_DIFF_PORT} \
-            -p ${TITAN_STATE_DIFF_PORT}:${TITAN_STATE_DIFF_PORT} \
-            -p ${FB_RPC_PORT}:${FB_RPC_PORT} \
-            -p ${TITAN_RPC_PORT}:${TITAN_RPC_PORT} \
-            -p ${EL_P2P_PORT}:${EL_P2P_PORT} \
             -p ${ENGINE_API_PORT}:${ENGINE_API_PORT} \
+            -p ${EL_P2P_PORT}:${EL_P2P_PORT} \
             -v /etc/searcher_key:/container_auth_keys:ro \
             -v /persistent:/persistent \
             -v /etc/searcher/ssh_hostkey:/etc/searcher/ssh_hostkey:rw \

--- a/recipes-core/searcher-container/files/searcher-pod-init
+++ b/recipes-core/searcher-container/files/searcher-pod-init
@@ -18,35 +18,68 @@ SEARCHER_SSH_PORT=10022
 ENGINE_API_PORT=8551
 EL_P2P_PORT=30303
 
+start_searcher_container() {
+    mkdir -p /etc/searcher/ssh_hostkey
+    chown searcher:searcher /etc/searcher/ssh_hostkey
+
+    echo "Starting $NAME..."
+    su -s /bin/sh $USER -c "cd ~ && $DAEMON run -d \
+        --name $NAME \
+        -p ${SEARCHER_SSH_PORT}:22 \
+        -p ${ENGINE_API_PORT}:${ENGINE_API_PORT} \
+        -p ${EL_P2P_PORT}:${EL_P2P_PORT} \
+        -v /etc/searcher_key:/container_auth_keys:ro \
+        -v /persistent:/persistent \
+        -v /etc/searcher/ssh_hostkey:/etc/searcher/ssh_hostkey:rw \
+        -v /searcher_logs:/var/log/searcher \
+        -v /var/volatile/jwt.hex:/secrets/jwt.hex:rw \
+        docker.io/library/ubuntu:24.04 \
+        /bin/sh -c ' \
+            DEBIAN_FRONTEND=noninteractive apt-get update && \
+            DEBIAN_FRONTEND=noninteractive apt-get install -y openssh-server && \
+            mkdir -p /run/sshd && \
+            mkdir -p /root/.ssh && \
+            cp /container_auth_keys /root/.ssh/authorized_keys && \
+            chmod 700 /root/.ssh && \
+            chmod 600 /root/.ssh/authorized_keys && \
+            cp /etc/ssh/ssh_host_ed25519_key.pub /etc/searcher/ssh_hostkey/host_key.pub && \
+            /usr/sbin/sshd -D -e'"
+}
+
+apply_firewall_rules() {
+    # Attempt a quick check that the container is running
+    for i in 1 2 3 4 5; do
+        status=$(su -s /bin/sh - $USER -c "$DAEMON inspect --format '{{.State.Status}}' $NAME 2>/dev/null || true")
+        if [ "$status" = "running" ]; then
+            break
+        fi
+        echo "Waiting for $NAME container to reach 'running' state..."
+        sleep 1
+    done
+
+    if [ "$status" != "running" ]; then
+        echo "ERROR: $NAME container is not running (status: $status)"
+        return 1
+    fi
+
+    # Retrieve the PID
+    pid=$(su -s /bin/sh - $USER -c "$DAEMON inspect --format '{{.State.Pid}}' $NAME")
+    if [ -z "$pid" ] || [ "$pid" = "0" ]; then
+        echo "ERROR: Could not retrieve PID for container $NAME."
+        return 1
+    fi
+
+    echo "Applying iptables rules in $NAME (PID: $pid) network namespace..."
+
+    # Enter network namespace and apply DROP rules on port 9000 TCP/UDP
+    nsenter --target "$pid" --net iptables -A OUTPUT -p tcp --dport 9000 -j DROP
+    nsenter --target "$pid" --net iptables -A OUTPUT -p udp --dport 9000 -j DROP
+}
+
 case "$1" in
     start)
-
-        mkdir -p /etc/searcher/ssh_hostkey
-        chown searcher:searcher /etc/searcher/ssh_hostkey   
-
-        echo "Starting $NAME..."
-        su -s /bin/sh $USER -c "cd ~ && $DAEMON run -d \
-            --name $NAME \
-            -p ${SEARCHER_SSH_PORT}:22 \
-            -p ${ENGINE_API_PORT}:${ENGINE_API_PORT} \
-            -p ${EL_P2P_PORT}:${EL_P2P_PORT} \
-            -v /etc/searcher_key:/container_auth_keys:ro \
-            -v /persistent:/persistent \
-            -v /etc/searcher/ssh_hostkey:/etc/searcher/ssh_hostkey:rw \
-            -v /searcher_logs:/var/log/searcher \
-            -v /var/volatile/jwt.hex:/secrets/jwt.hex:rw \
-            docker.io/library/ubuntu:24.04 \
-            /bin/sh -c ' \
-                DEBIAN_FRONTEND=noninteractive apt-get update && \
-                DEBIAN_FRONTEND=noninteractive apt-get install -y openssh-server && \
-                mkdir -p /run/sshd && \
-                mkdir -p /root/.ssh && \
-                cp /container_auth_keys /root/.ssh/authorized_keys && \
-                chmod 700 /root/.ssh && \
-                chmod 600 /root/.ssh/authorized_keys && \
-                cp /etc/ssh/ssh_host_ed25519_key.pub /etc/searcher/ssh_hostkey/host_key.pub && \
-                /usr/sbin/sshd -D -e'"
-
+        start_searcher_container
+        apply_firewall_rules
         ;;
     stop)
         echo "Stopping $NAME..."

--- a/recipes-core/searcher-container/files/toggle
+++ b/recipes-core/searcher-container/files/toggle
@@ -156,11 +156,57 @@ configure_mode_rules() {
     return 0
 }
 
+###############################################################################
+# Container Namespace Rule Verification
+###############################################################################
+check_searcher_namespace_rules() {
+    local cont_name="searcher-container"
+    local user="searcher"
+    local daemon="/usr/bin/podman"
+
+    # 1) Check container status
+    local status
+    status=$(su -s /bin/sh - $user -c "$daemon inspect --format '{{.State.Status}}' $cont_name 2>/dev/null" || true)
+    if [ "$status" != "running" ]; then
+        echo "ERROR: '$cont_name' container is not running; cannot verify rules."
+        return 1
+    fi
+
+    # 2) Retrieve the container PID
+    local pid
+    pid=$(su -s /bin/sh - $user -c "$daemon inspect --format '{{.State.Pid}}' $cont_name 2>/dev/null" || true)
+    if [ -z "$pid" ] || [ "$pid" = "0" ]; then
+        echo "ERROR: Could not retrieve PID for '$cont_name'."
+        return 1
+    fi
+
+    # 3) Check if the DROP rule on port 9000 is present in OUTPUT chain
+    #    -C (check) returns 0 if a matching rule is found, 1 otherwise
+    if nsenter --target "$pid" --net $IPTABLES -C OUTPUT -p tcp --dport 9000 -j DROP 2>/dev/null \
+       && nsenter --target "$pid" --net $IPTABLES -C OUTPUT -p udp --dport 9000 -j DROP 2>/dev/null; then
+        echo "OK: searcher-container firewall rules (DROP tcp/udp port 9000) are ACTIVE."
+        return 0
+    else
+        echo "WARNING: One or both searcher-container firewall rules (DROP port 9000) are NOT found."
+        return 1
+    fi
+}
+
+###############################################################################
+# Mode Switching Functions
+###############################################################################
 move_to_production() {
     if [ "$(get_state)" != "maintenance" ]; then
         echo "Error: Can only move to production from maintenance state"
         return 1
     fi
+
+    # Check the searcher-container-netns iptables rules are active first:
+    if ! check_searcher_namespace_rules; then
+        echo "Error: Required searcher-container-netns iptables rules not active!"
+        return 1
+    fi
+
     echo "Moving to production mode..."
     if configure_mode_rules "production" "maintenance"; then
         set_state "production"

--- a/recipes-core/searcher-container/files/toggle
+++ b/recipes-core/searcher-container/files/toggle
@@ -1,4 +1,14 @@
 #!/bin/sh
+#
+# Mode Switching Script
+#
+# Switch Paths:
+# 1) "production" -> "stopped"
+# 2) "stopped" -> "maintenance" (two minute delay)
+# 3) "maintenance" -> "production"
+# 
+# Terminating NEW connections: Uses MODE_SELECTOR IN/OUT chain jumps to MAINTENANCE_IN/OUT or PRODUCTION_IN/OUT rule sets
+# Terminating ESTABLISHED/RELATED connections: Uses conntrack to kill all current connections by port
 
 # We must be root to change iptable rules
 # Check if we're root, if not, fail
@@ -7,31 +17,41 @@ if [ "$(id -u)" != "0" ]; then
     exit 1
 fi
 
+###############################################################################
+# Configuration
+###############################################################################
+
+# Delay implementationfiles
 LOCK_FILE="/etc/searcher-network.lock"
 STATE_FILE="/etc/searcher-network.state"
 TIMESTAMP_FILE="/etc/searcher-network-last-stop.timestamp"
 
-PODMAN="/usr/bin/podman"
-CONTAINER_NAME="searcher-container"
+# Tools
 IPTABLES="/usr/sbin/iptables"
+CONNTRACK="/usr/sbin/conntrack"
 
-# iptable chain names
-SEARCHER_INPUT="SEARCHER_INPUT"
-SEARCHER_OUTPUT="SEARCHER_OUTPUT"
-SEARCHER_MODE="SEARCHER_MODE" 
-SEARCHER_BASE="SEARCHER_BASE"     
-SEARCHER_BASE_ESTABLISHED="SEARCHER_BASE_ESTABLISHED"
-SEARCHER_MODE_ESTABLISHED="SEARCHER_MODE_ESTABLISHED"
+# Chains
+CHAIN_MODE_SELECTOR_IN="MODE_SELECTOR_IN"
+CHAIN_MODE_SELECTOR_OUT="MODE_SELECTOR_OUT"
+CHAIN_MAINTENANCE_IN="MAINTENANCE_IN"
+CHAIN_MAINTENANCE_OUT="MAINTENANCE_OUT"
+CHAIN_PRODUCTION_IN="PRODUCTION_IN"
+CHAIN_PRODUCTION_OUT="PRODUCTION_OUT"
 
-# Port configurations
+# Maintenance ports
 SSH_DATA_PORT=10022
-FB_STATE_DIFF_PORT=8547
-TITAN_STATE_DIFF_PORT=8548
-EL_P2P_PORT=30303
 DNS_PORT=53
-HTTPS_PORT=443
 HTTP_PORT=80
+HTTPS_PORT=443
+EL_P2P_PORT=30303
 
+# Production ports
+FB_STATE_DIFF_PORT=8547
+TITAN_STATE_DIFF_PORT=42202
+
+###############################################################################
+# Delay between stopping and starting maintenance
+###############################################################################
 with_lock() {
     (
         flock -x 200
@@ -73,74 +93,67 @@ check_delay() {
     return 0
 }
 
-# New function to manage iptables rules
-configure_mode_rules() {
-    local mode=$1
-    
-    # First, flush mode-specific rules
-    $IPTABLES -F $SEARCHER_MODE
-    $IPTABLES -F $SEARCHER_MODE_ESTABLISHED
-    
-    # Add new rules based on mode
-    if [ "$mode" = "maintenance" ]; then
-        # Then enable SSH access
-        $IPTABLES -A $SEARCHER_MODE -p tcp --dport $SSH_DATA_PORT -j ACCEPT
-        $IPTABLES -A $SEARCHER_MODE_ESTABLISHED -p tcp --sport $SSH_DATA_PORT -m state --state ESTABLISHED,RELATED -j ACCEPT
+###############################################################################
+# Kill established connections via conntrack
+###############################################################################
+kill_established_connections() {
+    local old_mode="$1"
+    if [ "$old_mode" = "production" ]; then
+        echo "Killing leftover production flows (ports $FB_STATE_DIFF_PORT, $TITAN_STATE_DIFF_PORT)..."
+        $CONNTRACK -D -p tcp --dport $FB_STATE_DIFF_PORT 2>/dev/null
+        $CONNTRACK -D -p tcp --dport $TITAN_STATE_DIFF_PORT 2>/dev/null
 
-        # Execution Client P2P
-        $IPTABLES -A $SEARCHER_MODE -p tcp --dport $EL_P2P_PORT -j ACCEPT
-        $IPTABLES -A $SEARCHER_MODE -p tcp --sport $EL_P2P_PORT -j ACCEPT
-        $IPTABLES -A $SEARCHER_MODE -p udp --dport $EL_P2P_PORT -j ACCEPT
-        $IPTABLES -A $SEARCHER_MODE -p udp --sport $EL_P2P_PORT -j ACCEPT
-        $IPTABLES -A $SEARCHER_MODE_ESTABLISHED -p tcp --sport $EL_P2P_PORT -m state --state ESTABLISHED -j ACCEPT
-        $IPTABLES -A $SEARCHER_MODE_ESTABLISHED -p tcp --dport $EL_P2P_PORT -m state --state ESTABLISHED -j ACCEPT
-        $IPTABLES -A $SEARCHER_MODE_ESTABLISHED -p udp --sport $EL_P2P_PORT -m state --state ESTABLISHED -j ACCEPT
-        $IPTABLES -A $SEARCHER_MODE_ESTABLISHED -p udp --dport $EL_P2P_PORT -m state --state ESTABLISHED -j ACCEPT
-        
-        # Enable DNS access (both UDP and TCP)
-        # Inbound DNS
-        $IPTABLES -A $SEARCHER_MODE -p udp --dport $DNS_PORT -j ACCEPT
-        $IPTABLES -A $SEARCHER_MODE -p tcp --dport $DNS_PORT -j ACCEPT
-        $IPTABLES -A $SEARCHER_MODE_ESTABLISHED -p udp --sport $DNS_PORT -m state --state ESTABLISHED,RELATED -j ACCEPT
-        $IPTABLES -A $SEARCHER_MODE_ESTABLISHED -p tcp --sport $DNS_PORT -m state --state ESTABLISHED,RELATED -j ACCEPT
-        # Outbound DNS
-        $IPTABLES -A $SEARCHER_MODE -p udp --sport $DNS_PORT -j ACCEPT
-        $IPTABLES -A $SEARCHER_MODE -p tcp --sport $DNS_PORT -j ACCEPT
-        $IPTABLES -A $SEARCHER_MODE_ESTABLISHED -p udp --dport $DNS_PORT -m state --state ESTABLISHED,RELATED -j ACCEPT
-        $IPTABLES -A $SEARCHER_MODE_ESTABLISHED -p tcp --dport $DNS_PORT -m state --state ESTABLISHED,RELATED -j ACCEPT
-        
-        # Enable HTTPS access
-        # Inbound HTTPS
-        $IPTABLES -A $SEARCHER_MODE -p tcp --dport $HTTPS_PORT -j ACCEPT
-        $IPTABLES -A $SEARCHER_MODE_ESTABLISHED -p tcp --sport $HTTPS_PORT -m state --state ESTABLISHED,RELATED -j ACCEPT
-        # Outbound HTTPS
-        $IPTABLES -A $SEARCHER_MODE -p tcp --sport $HTTPS_PORT -j ACCEPT
-        $IPTABLES -A $SEARCHER_MODE_ESTABLISHED -p tcp --dport $HTTPS_PORT -m state --state ESTABLISHED,RELATED -j ACCEPT
-
-        # Enable HTTP access
-        # Inbound HTTP
-        $IPTABLES -A $SEARCHER_MODE -p tcp --dport $HTTP_PORT -j ACCEPT
-        $IPTABLES -A $SEARCHER_MODE_ESTABLISHED -p tcp --sport $HTTP_PORT -m state --state ESTABLISHED,RELATED -j ACCEPT
-        # Outbound HTTP
-        $IPTABLES -A $SEARCHER_MODE -p tcp --sport $HTTP_PORT -j ACCEPT
-        $IPTABLES -A $SEARCHER_MODE_ESTABLISHED -p tcp --dport $HTTP_PORT -m state --state ESTABLISHED,RELATED -j ACCEPT
-        
-    elif [ "$mode" = "production" ]; then
-        # Enable state diff streams
-        $IPTABLES -A $SEARCHER_MODE -p tcp --dport $FB_STATE_DIFF_PORT -j ACCEPT
-        $IPTABLES -A $SEARCHER_MODE_ESTABLISHED -p tcp --sport $FB_STATE_DIFF_PORT -m state --state ESTABLISHED,RELATED -j ACCEPT
-        $IPTABLES -A $SEARCHER_MODE_ESTABLISHED -p tcp --dport $FB_STATE_DIFF_PORT -m state --state ESTABLISHED,RELATED -j ACCEPT
-        
-    else  # stopped state
-        # Drop SSH connections
-        $IPTABLES -A $SEARCHER_MODE -p tcp --dport $SSH_DATA_PORT -j DROP
-        $IPTABLES -A $SEARCHER_MODE_ESTABLISHED -p tcp --sport $SSH_DATA_PORT -j DROP
-
-        # Drop state diff connections
-        $IPTABLES -A $SEARCHER_MODE -p tcp --dport $FB_STATE_DIFF_PORT -j DROP
-        $IPTABLES -A $SEARCHER_MODE_ESTABLISHED -p tcp --sport $FB_STATE_DIFF_PORT -j DROP
-        $IPTABLES -A $SEARCHER_MODE_ESTABLISHED -p tcp --dport $FB_STATE_DIFF_PORT -j DROP
+    elif [ "$old_mode" = "maintenance" ]; then
+        echo "Killing leftover maintenance flows:"
+        echo " - SSH data port $SSH_DATA_PORT"
+        echo " - DNS $DNS_PORT, HTTP $HTTP_PORT, HTTPS $HTTPS_PORT, EL P2P $EL_P2P_PORT"
+        # SSH data plane
+        $CONNTRACK -D -p tcp --dport $SSH_DATA_PORT 2>/dev/null
+        # DNS
+        $CONNTRACK -D -p tcp --dport $DNS_PORT 2>/dev/null
+        $CONNTRACK -D -p udp --dport $DNS_PORT 2>/dev/null
+        # HTTP/HTTPS
+        $CONNTRACK -D -p tcp --dport $HTTP_PORT 2>/dev/null
+        $CONNTRACK -D -p tcp --dport $HTTPS_PORT 2>/dev/null
+        # EL P2P
+        $CONNTRACK -D -p tcp --dport $EL_P2P_PORT 2>/dev/null
+        $CONNTRACK -D -p udp --dport $EL_P2P_PORT 2>/dev/null
     fi
+    # if old_mode="stopped", nothing to kill
+}
+###############################################################################
+# Toggle the iptables chain jumps
+###############################################################################
+configure_mode_rules() {
+    local new_mode="$1"
+    local old_mode="$2"
+    
+    # 1) Kill all established flows from old mode
+    kill_established_connections "$old_mode"
+
+    # 2) Flush the mode selector so we remove references to the old sub-chain
+    $IPTABLES -F $CHAIN_MODE_SELECTOR_IN
+    $IPTABLES -F $CHAIN_MODE_SELECTOR_OUT
+
+    # 3) Depending on new_mode, jump to the matching sub-chains
+    case "$new_mode" in
+      maintenance)
+        $IPTABLES -A $CHAIN_MODE_SELECTOR_IN  -j $CHAIN_MAINTENANCE_IN
+        $IPTABLES -A $CHAIN_MODE_SELECTOR_OUT -j $CHAIN_MAINTENANCE_OUT
+        ;;
+      production)
+        $IPTABLES -A $CHAIN_MODE_SELECTOR_IN  -j $CHAIN_PRODUCTION_IN
+        $IPTABLES -A $CHAIN_MODE_SELECTOR_OUT -j $CHAIN_PRODUCTION_OUT
+        ;;
+      stopped)
+        # No jump => default DROP. 
+        ;;
+      *)
+        echo "Unknown mode $new_mode in configure_mode_rules"
+        return 1
+        ;;
+    esac
+    return 0
 }
 
 move_to_production() {
@@ -149,7 +162,7 @@ move_to_production() {
         return 1
     fi
     echo "Moving to production mode..."
-    if configure_mode_rules "production"; then
+    if configure_mode_rules "production" "maintenance"; then
         set_state "production"
         echo "Successfully switched to production mode"
         return 0
@@ -166,7 +179,7 @@ disconnect_from_production() {
         return 1
     fi
     echo "Disconnecting from production mode..."
-    if configure_mode_rules "stopped"; then
+    if configure_mode_rules "stopped" "production"; then
         set_state "stopped"
         echo "Successfully disconnected from production mode"
         return 0
@@ -185,7 +198,7 @@ connect_to_maintenance() {
         return 1
     fi
     echo "Connecting to maintenance mode..."
-    if configure_mode_rules "maintenance"; then
+    if configure_mode_rules "maintenance" "stopped"; then
         set_state "maintenance"
         rm -f "$TIMESTAMP_FILE"  # Clear timestamp after successful use
         echo "Successfully connected to maintenance mode"


### PR DESCRIPTION
There were two major problems with the previous firewalling approach:
A. INPUT and OUTPUT jumped to the same MODE chains, deceptively allowing both inbound and outbound for each rule written for the mode chains.
B. During production mode, we have a rule on host iptables that allows any outbound traffic to a destination port 9000. This is necessary for our lighthouse CL client run on the host to stay in sync with the p2p network. However, this is also a free port for the searcher container to leak state diffs from! 

This PR:
1. For each mode, creates MODE_IN and MODE_OUT (Fixes A) 
2. Uses conntrack to explicitly kill established connections. 
3. Blocks outbound through port 9000 in the **searcher netns iptables**. (Fixes B) 

The new firewall chain flow:
```
[Inbound Packet]
   │
   ▼
 (INPUT Chain)
   ├─(ESTABLISHED/RELATED?)─> ACCEPT
   ├─> ALWAYS_ON_IN ──> Return
   └─> MODE_SELECTOR_IN 
         ├─> jumps MAINTENANCE_IN or PRODUCTION_IN ─> Return
         └─> end => default DROP


[Outbound Packet]
   │
   ▼
 (OUTPUT Chain)
   ├─(ESTABLISHED/RELATED?)─> ACCEPT
   ├─> ALWAYS_ON_OUT ──> Return
   └─> MODE_SELECTOR_OUT
         ├─> jumps MAINTENANCE_OUT or PRODUCTION_OUT ─> Return
         └─> end => default DROP
 ```
 
- When a new packet arrives, `ALWAYS_ON_IN` and `ALWAYS_ON_OUT` accept a set of connections which are on regardless of the mode, such as the SSH toggle port 22. 
- Maintenance and production rules also each have their own chain of allowed inputs and allowed outputs. 
- **Mode switching** is done by flushing and jumping to the respective mode's input and output chains. During mode switches, conntrack -D <set of mode ports> is also run, which deletes all traces of the connection in the kernel. 

The searcher netns iptables rules have a default accept policy, and implements two rules dropping outbound to port 9000 through UDP & TCP. 
- The rules are applied on the start function of the searcher podman container, to ensure whenever a new searcher container is started, these rules are applied.
- To be robust, the searcher netns rules are verified in the toggle script before switching to production mode. 

Here is our final networking layout:
![BOB NETWORKING OMG](https://github.com/user-attachments/assets/5983757c-157c-4a1a-994b-7d72dd216d81)

Testing:
- verified mode rules with iptables -L and conntrack -L
- verified curl from container to port 9000 fails
```

root@6aaadb861f4c:~# curl -v --connect-timeout 5 http://google.com:9000
* Host google.com:9000 was resolved.
* IPv6: 2607:f8b0:4020:800::200e
* IPv4: 142.250.69.46
*   Trying 142.250.69.46:9000...
*   Trying [2607:f8b0:4020:800::200e]:9000...
* Immediate connect fail for 2607:f8b0:4020:800::200e: Network is unreachable
* ipv4 connect timeout after 4998ms, move on!
* Failed to connect to google.com port 9000 after 5002 ms: Timeout was reached
* Closing connection
curl: (28) Failed to connect to google.com port 9000 after 5002 ms: Timeout was reached

root@6aaadb861f4c:~# curl -v --connect-timeout 5 http://google.com:80
* Host google.com:80 was resolved.
```