### PR TITLE
Fix: Change searcher ownership of /persistent to /persistent/searcher

### DIFF
--- a/recipes-core/searcher-container/files/searcher-pod-init
+++ b/recipes-core/searcher-container/files/searcher-pod-init
@@ -22,6 +22,10 @@ SEARCHER_INPUT_CHANNEL=27017
 start_searcher_container() {
     mkdir -p /etc/searcher/ssh_hostkey
     chown searcher:searcher /etc/searcher/ssh_hostkey
+    
+    # Ensure /persistent/searcher is owned by the searcher user
+    mkdir -p /persistent/searcher
+    chown -R searcher:searcher /persistent/searcher
 
     echo "Starting $NAME..."
     su -s /bin/sh $USER -c "cd ~ && $DAEMON run -d \
@@ -31,7 +35,7 @@ start_searcher_container() {
         -p ${EL_P2P_PORT}:${EL_P2P_PORT} \
         -p ${SEARCHER_INPUT_CHANNEL}:${SEARCHER_INPUT_CHANNEL} \
         -v /etc/searcher_key:/container_auth_keys:ro \
-        -v /persistent:/persistent \
+        -v /persistent/searcher:/persistent:rw \
         -v /etc/searcher/ssh_hostkey:/etc/searcher/ssh_hostkey:rw \
         -v /searcher_logs:/var/log/searcher \
         -v /var/volatile/jwt.hex:/secrets/jwt.hex:rw \

--- a/recipes-core/su-restriction/files/restrict-su.sh
+++ b/recipes-core/su-restriction/files/restrict-su.sh
@@ -11,10 +11,7 @@
 case "$1" in
   start)
     echo "Implementing su and root access restrictions"
-    
-    # Ensure the persistent directory is owned by the searcher user
-    chown -R searcher:searcher /persistent 
-    
+
     # Remove execute permissions from su for non-root users
     chmod 700 /bin/su
     


### PR DESCRIPTION
Lighthouse, which is run on the host, uses /persistent as the data directory. 
We don't want the searcher to be able to write or modify lighthouse files. 
So, we give the searcher user ownership of only /persistent/searcher directory, which we mount to the container.

Previous ownership: 
```
# host pov
root@tdx:~# ls -la /persistent
total 0
drwxr-xr-x    3 searcher searcher         0 Feb  2 13:56 .
drwxr-xr-x   21 root     root             0 Feb  2 13:56 ..
drwxr-xr-x    3 searcher searcher         0 Feb  2 13:56 lighthouse

# container pov
root@8995bb0330a8:~# ls -la /persistent
total 0
drwxr-xr-x  3 root root 0 Feb  2 13:56 .
dr-xr-xr-x 20 root root 0 Feb  2 13:56 ..
drwxr-xr-x  3 root root 0 Feb  2 13:56 lighthouse
```

Now:
```
# host pov
root@tdx:~# ls -la /persistent
total 0
drwxr-xr-x    4 root     root             0 Feb  2 14:12 .
drwxr-xr-x   21 root     root             0 Feb  2 14:12 ..
drwxr-xr-x    3 root     root             0 Feb  2 14:12 lighthouse
drwxr-xr-x    2 searcher searcher         0 Feb  2 14:12 searcher

# container pov
root@a5dda0712876:~# ls -la /persistent
total 0
drwxr-xr-x  3 root root 0 Feb  2 14:13 .
dr-xr-xr-x 20 root root 0 Feb  2 14:13 ..
drwxr-xr-x  2 root root 0 Feb  2 14:12 searcher
```