### PR TITLE
Bug fixes from flashbots internal audit

### DIFF
--- a/recipes-core/fluentbit-container/files/delay.lua
+++ b/recipes-core/fluentbit-container/files/delay.lua
@@ -2,11 +2,8 @@
 -- Lua script stays in memory for the lifetime of the Fluent Bit process,
 -- so all local variables persist across filter calls.
 
-local DELAY_SEC = 120 -- Delay (in seconds) before flushing logs
+local DELAY_SEC = 20 -- Delay (in seconds) before flushing logs
 local buckets = {} -- Table to bucket logs by their timestamp (seconds)
-local current_buffered_records = 0 -- Number of currently buffered logs, kept track of manually
-local MAX_BUFFERED_LOG_RECORDS = 65536 -- Max amount of log records to keep in memory before truncating
-local truncated_buckets = {} -- Tracks which timestamps were truncated (and emits that information only when the time comes)
 local earliest_sec = nil -- Tracks the earliest second we have in our buckets table
 local last_processed_second = nil -- Tracks which second we last ran the flush logic on
 
@@ -20,17 +17,11 @@ function log_delay(tag, ts_table, record)
         earliest_sec = arrival_sec
     end
 
-	-- Check if we are not exceeding the limit of records
-	if current_buffered_records < MAX_BUFFERED_LOG_RECORDS then
-		-- 1) Insert the new record into its bucket
-		if not buckets[arrival_sec] then
-			buckets[arrival_sec] = {}
-		end
-		table.insert(buckets[arrival_sec], record)
-		current_buffered_records = current_buffered_records + 1
-	else
-		truncated_buckets[arrival_sec] = true
-	end
+    -- 1) Insert the new record into its bucket
+    if not buckets[arrival_sec] then
+        buckets[arrival_sec] = {}
+    end
+    table.insert(buckets[arrival_sec], record)
 
     -- 2) Check if we've already processed this second
     if last_processed_second == now_floor then
@@ -43,31 +34,18 @@ function log_delay(tag, ts_table, record)
     local to_emit = {}
 
     -- Flush all buckets whose second <= (now_sec - DELAY_SEC)
-	local buckets_were_truncated = false
     while earliest_sec and earliest_sec <= (now_sec - DELAY_SEC) do
-		buckets_were_truncated = buckets_were_truncated || truncated_buckets[earliest_sec] 
-		table.remove(truncated_buckets, earliest_sec) 
-
         local bucket_logs = buckets[earliest_sec]
         if bucket_logs then
-            -- Move all logs in this bucket to 'to_emit'
-            for _, old_record in ipairs(bucket_logs) do
-                table.insert(to_emit, old_record)
-				current_buffered_records = current_buffered_records - 1
-            end
-			-- TODO: should probably delete right?
+            -- Use table.move to quickly merge bucket_logs into to_emit
+            -- (start index = 1, end index = #bucket_logs, insert destination = #to_emit+1)
+            table.move(bucket_logs, 1, #bucket_logs, #to_emit + 1, to_emit)
             buckets[earliest_sec] = nil
-            table.remove(buckets, earliest_sec)
         end
 
         -- Move on to the next second
         earliest_sec = earliest_sec + 1
     end
-
-	-- 3.5) Append truncation notice if any
-	if buckets_were_truncated then
-		table.insert(to_emit, {"Some entries were truncated!"})
-	end
 
     -- 4) Return any flushed logs
     if #to_emit == 0 then

--- a/recipes-core/fluentbit-container/files/delay.lua
+++ b/recipes-core/fluentbit-container/files/delay.lua
@@ -2,7 +2,7 @@
 -- Lua script stays in memory for the lifetime of the Fluent Bit process,
 -- so all local variables persist across filter calls.
 
-local DELAY_SEC = 20 -- Delay (in seconds) before flushing logs
+local DELAY_SEC = 120 -- Delay (in seconds) before flushing logs
 local buckets = {} -- Table to bucket logs by their timestamp (seconds)
 local earliest_sec = nil -- Tracks the earliest second we have in our buckets table
 local last_processed_second = nil -- Tracks which second we last ran the flush logic on

--- a/recipes-core/fluentbit-container/files/delay.lua
+++ b/recipes-core/fluentbit-container/files/delay.lua
@@ -4,6 +4,9 @@
 
 local DELAY_SEC = 120 -- Delay (in seconds) before flushing logs
 local buckets = {} -- Table to bucket logs by their timestamp (seconds)
+local current_buffered_records = 0 -- Number of currently buffered logs, kept track of manually
+local MAX_BUFFERED_LOG_RECORDS = 65536 -- Max amount of log records to keep in memory before truncating
+local truncated_buckets = {} -- Tracks which timestamps were truncated (and emits that information only when the time comes)
 local earliest_sec = nil -- Tracks the earliest second we have in our buckets table
 local last_processed_second = nil -- Tracks which second we last ran the flush logic on
 
@@ -17,11 +20,17 @@ function log_delay(tag, ts_table, record)
         earliest_sec = arrival_sec
     end
 
-    -- 1) Insert the new record into its bucket
-    if not buckets[arrival_sec] then
-        buckets[arrival_sec] = {}
-    end
-    table.insert(buckets[arrival_sec], record)
+	-- Check if we are not exceeding the limit of records
+	if current_buffered_records < MAX_BUFFERED_LOG_RECORDS then
+		-- 1) Insert the new record into its bucket
+		if not buckets[arrival_sec] then
+			buckets[arrival_sec] = {}
+		end
+		table.insert(buckets[arrival_sec], record)
+		current_buffered_records = current_buffered_records + 1
+	else
+		truncated_buckets[arrival_sec] = true
+	end
 
     -- 2) Check if we've already processed this second
     if last_processed_second == now_floor then
@@ -34,19 +43,31 @@ function log_delay(tag, ts_table, record)
     local to_emit = {}
 
     -- Flush all buckets whose second <= (now_sec - DELAY_SEC)
+	local buckets_were_truncated = false
     while earliest_sec and earliest_sec <= (now_sec - DELAY_SEC) do
+		buckets_were_truncated = buckets_were_truncated || truncated_buckets[earliest_sec] 
+		table.remove(truncated_buckets, earliest_sec) 
+
         local bucket_logs = buckets[earliest_sec]
         if bucket_logs then
             -- Move all logs in this bucket to 'to_emit'
             for _, old_record in ipairs(bucket_logs) do
                 table.insert(to_emit, old_record)
+				current_buffered_records = current_buffered_records - 1
             end
+			-- TODO: should probably delete right?
             buckets[earliest_sec] = nil
+            table.remove(buckets, earliest_sec)
         end
 
         -- Move on to the next second
         earliest_sec = earliest_sec + 1
     end
+
+	-- 3.5) Append truncation notice if any
+	if buckets_were_truncated then
+		table.insert(to_emit, {"Some entries were truncated!"})
+	end
 
     -- 4) Return any flushed logs
     if #to_emit == 0 then

--- a/recipes-core/fluentbit-container/files/fluentbit-pod-init
+++ b/recipes-core/fluentbit-container/files/fluentbit-pod-init
@@ -19,6 +19,11 @@ CONFIG_PATH=/etc/fluentbit/config/fluentbit.conf
 
 case "$1" in
     start)
+
+        # Note: fluentbit automatically creates /var/log/fluentbit/output.log (/delayed_logs/output.log on the host)
+        # Permissions: -rw-r--r--    1 fluentbi adm            175 Feb  6 21:01 output.log
+        # R/W by fluentbit user, read only by searcher user
+
         echo "Starting $NAME..."
         su -s /bin/sh $USER -c "cd ~ && $DAEMON run -d \
             --name $NAME \

--- a/recipes-core/fluentbit-container/files/fluentbit-pod-init
+++ b/recipes-core/fluentbit-container/files/fluentbit-pod-init
@@ -20,6 +20,13 @@ CONFIG_PATH=/etc/fluentbit/config/fluentbit.conf
 case "$1" in
     start)
 
+        # Create directory for delayed logs
+        mkdir -p /persistent/delayed_logs
+
+        # 2) Change its owner to fluentbit and set permissions
+        chown fluentbit:fluentbit /persistent/delayed_logs
+        chmod 755 /persistent/delayed_logs
+
         # Note: fluentbit automatically creates /var/log/fluentbit/output.log (/delayed_logs/output.log on the host)
         # Permissions: -rw-r--r--    1 fluentbi adm            175 Feb  6 21:01 output.log
         # R/W by fluentbit user, read only by searcher user
@@ -29,8 +36,8 @@ case "$1" in
             --name $NAME \
             --restart=always \
             -v $CONFIG_PATH:/fluent-bit/etc/fluent-bit.conf:ro \
-            -v /delayed_logs:/var/log/fluentbit:rw \
-            -v /searcher_logs:/var/log/searcher:ro \
+            -v /persistent/delayed_logs:/var/log/fluentbit:rw \
+            -v /persistent/searcher_logs:/var/log/searcher:ro \
             -v /etc/fluentbit/config/delay.lua:/fluent-bit/etc/delay.lua:ro \
             docker.io/fluent/fluent-bit:3.2.4@sha256:d2e5b2fe876ca343ff68e431a62249caba2f5300bd340145b1f30bdacedf3a6a \
             /fluent-bit/bin/fluent-bit --config /fluent-bit/etc/fluent-bit.conf"

--- a/recipes-core/fluentbit-container/files/fluentbit-pod-init
+++ b/recipes-core/fluentbit-container/files/fluentbit-pod-init
@@ -27,10 +27,6 @@ case "$1" in
         chown fluentbit:fluentbit /persistent/delayed_logs
         chmod 755 /persistent/delayed_logs
 
-        # Note: fluentbit automatically creates /var/log/fluentbit/output.log (/delayed_logs/output.log on the host)
-        # Permissions: -rw-r--r--    1 fluentbi adm            175 Feb  6 21:01 output.log
-        # R/W by fluentbit user, read only by searcher user
-
         echo "Starting $NAME..."
         su -s /bin/sh $USER -c "cd ~ && $DAEMON run -d \
             --name $NAME \

--- a/recipes-core/fluentbit-container/fluentbit-container.bb
+++ b/recipes-core/fluentbit-container/fluentbit-container.bb
@@ -24,7 +24,6 @@ INITSCRIPT_PACKAGES = "${PN}"
 INITSCRIPT_NAME:${PN} = "fluentbit-pod"
 INITSCRIPT_PARAMS:${PN} = "defaults 99"
 
-# Does it really depend on podman?
 RDEPENDS:${PN} = "podman modutils-initscripts"
 
 do_install() {

--- a/recipes-core/fluentbit-container/fluentbit-container.bb
+++ b/recipes-core/fluentbit-container/fluentbit-container.bb
@@ -24,6 +24,7 @@ INITSCRIPT_PACKAGES = "${PN}"
 INITSCRIPT_NAME:${PN} = "fluentbit-pod"
 INITSCRIPT_PARAMS:${PN} = "defaults 99"
 
+# Does it really depend on podman?
 RDEPENDS:${PN} = "podman modutils-initscripts"
 
 do_install() {

--- a/recipes-core/lighthouse/init
+++ b/recipes-core/lighthouse/init
@@ -32,7 +32,7 @@ monitor_and_restart() {
 }
 
 start_lighthouse() {
-		start-stop-daemon -S --make-pidfile -p $PIDFILE -N -10 -b -a /bin/sh -- -c "exec ${DAEMON} \
+		start-stop-daemon -S --make-pidfile -p $PIDFILE -b -a /bin/sh -- -c "exec ${DAEMON} \
 		bn \
 		--network mainnet \
 		--execution-endpoint http://localhost:8551 \

--- a/recipes-core/lighthouse/init
+++ b/recipes-core/lighthouse/init
@@ -50,8 +50,8 @@ start() {
     # Ensure the lighthouse log exists and has correct permissions
     touch $LOGFILE
 
-    # Ensure the LIGHTHOUSE_DIR exists and has correct permissions
-    mkdir -p $LIGHTHOUSE_DIR && chmod 0770 $LIGHTHOUSE_DIR
+    # Ensure the LIGHTHOUSE_DIR exists and only root can access it
+    mkdir -p $LIGHTHOUSE_DIR && chmod -R 700 $LIGHTHOUSE_DIR
 
     # Remount /var/volatile with increased size
     mount -o remount,size=90% /var/volatile

--- a/recipes-core/logrotate/files/fluentbit-logs.conf
+++ b/recipes-core/logrotate/files/fluentbit-logs.conf
@@ -1,15 +1,16 @@
 # /etc/logrotate.d/fluentbit-logs.conf
 #
 # Rotate logs in /delayed_logs and /searcher_logs daily,
-# keeping 7 old copies. Use copytruncate so Fluent Bit
+# keeping 5 old copies. Use copytruncate so Fluent Bit
 # doesn't lose its file handles.
 
  /delayed_logs/*.log /searcher_logs/*.log {
      daily
-     rotate 7
+     rotate 5
      copytruncate
      missingok
      notifempty
      compress        
      dateext         # suffix rotated logs with the date
+     maxsize 2G
  }

--- a/recipes-core/logrotate/files/fluentbit-logs.conf
+++ b/recipes-core/logrotate/files/fluentbit-logs.conf
@@ -4,7 +4,7 @@
 # keeping 5 old copies. Use copytruncate so Fluent Bit
 # doesn't lose its file handles.
 
- /delayed_logs/*.log /searcher_logs/*.log {
+ /persistent/delayed_logs/*.log /persistent/searcher_logs/*.log {
      daily
      rotate 5
      copytruncate

--- a/recipes-core/searcher-container/files/searcher-network-init
+++ b/recipes-core/searcher-container/files/searcher-network-init
@@ -12,7 +12,6 @@
 # Binaries
 ###############################################################################
 IPTABLES="/usr/sbin/iptables"
-IP6TABLES="/usr/sbin/ip6tables"
 CONNTRACK="/usr/sbin/conntrack"
 PODMAN="/usr/bin/podman"
 CONTAINER_NAME="searcher-container"

--- a/recipes-core/searcher-container/files/searcher-network-init
+++ b/recipes-core/searcher-container/files/searcher-network-init
@@ -38,13 +38,38 @@ HTTPS_PORT=443             # Outbound: HTTPS (maintenance mode only)
 
 SEARCHER_INPUT_CHANNEL=27017  # Inbound: Input Only Channel (always on)
 
-FLASHBOTS_STATE_DIFF=8547        # Outbound: Flashbots builder state diff (production only)
-FLASHBOTS_BUNDLE_ENDPOINT=8645   # Outbound: Flashbots builder bundle submission (production only)
-TITAN_STATE_DIFF=42202           # Outbound: Titan builder state diff (production only)
-TITAN_BUNDLE_ENDPOINT=1337       # Outbound: Titan builder bundle submission (production only)
+FLASHBOTS_STATE_DIFF_PORT=8547 # Outbound: Flashbots builder state diff (production only)
+FLASHBOTS_BUNDLE_PORT=8645     # Outbound: Flashbots builder bundle submission (production only)
+TITAN_STATE_DIFF_PORT=42202    # Outbound: Titan builder state diff (production only)
+TITAN_BUNDLE_PORT=1337         # Outbound: Titan builder bundle submission (production only)
 
 CVM_REVERSE_PROXY_PORT=8745      # Inbound: CVM reverse proxy (always on)
 
+###############################################################################
+# Network Flow Diagram
+###############################################################################
+#
+# [Inbound Packet]
+#    │
+#    ▼
+#  (INPUT Chain)
+#    ├─(ESTABLISHED/RELATED?)─> ACCEPT
+#    ├─> ALWAYS_ON_IN ──> Return
+#    └─> MODE_SELECTOR_IN 
+#          ├─> jumps MAINTENANCE_IN or PRODUCTION_IN ─> Return
+#          └─> end => default DROP
+#
+#
+# [Outbound Packet]
+#    │
+#    ▼
+#  (OUTPUT Chain)
+#    ├─(ESTABLISHED/RELATED?)─> ACCEPT
+#    ├─> ALWAYS_ON_OUT ──> Return
+#    └─> MODE_SELECTOR_OUT
+#          ├─> jumps MAINTENANCE_OUT or PRODUCTION_OUT ─> Return
+#          └─> end => default DROP
+#
 ###############################################################################
 # Custom Chains
 ###############################################################################
@@ -128,28 +153,32 @@ start_firewall() {
         -m conntrack --ctstate NEW -j ACCEPT
 
     # CVM reverse-proxy inbound on port 8745 (TCP)
+    # Serves server attestation 
+    # Also forwards request to ssh pubkey server on localhost:5001, 
+    #    which serves searcher-container openssh server pubkey 
     $IPTABLES -A $CHAIN_ALWAYS_ON_IN -p tcp --dport $CVM_REVERSE_PROXY_PORT \
         -m conntrack --ctstate NEW -j ACCEPT
 
-    # Return from ALWAYS_ON_IN
+    # Return from ALWAYS_ON_IN back to caller (INPUT chain -> MODE_SELECTOR_IN) 
     $IPTABLES -A $CHAIN_ALWAYS_ON_IN -j RETURN
 
     ###########################################################################
     # (7) ALWAYS_ON_OUT: Outbound rules that never turn off
     ###########################################################################
     # CL P2P outbound on port 9000 (TCP + UDP)
+    # Note: This is the lighthouse CL client run on the host, not the searcher's CL
     $IPTABLES -A $CHAIN_ALWAYS_ON_OUT -p tcp --dport $CL_P2P_PORT \
         -m conntrack --ctstate NEW -j ACCEPT
     $IPTABLES -A $CHAIN_ALWAYS_ON_OUT -p udp --dport $CL_P2P_PORT \
         -m conntrack --ctstate NEW -j ACCEPT
 
     # Flashbots & Titan builder bundle endpoints (always on)
-    $IPTABLES -A $CHAIN_ALWAYS_ON_OUT -p tcp -d $FLASHBOTS_BUILDER_IP --dport $FLASHBOTS_BUNDLE_ENDPOINT \
+    $IPTABLES -A $CHAIN_ALWAYS_ON_OUT -p tcp -d $FLASHBOTS_BUILDER_IP --dport $FLASHBOTS_BUNDLE_PORT \
         -m conntrack --ctstate NEW -j ACCEPT
-    $IPTABLES -A $CHAIN_ALWAYS_ON_OUT -p tcp -d $TITAN_BUILDER_IP --dport $TITAN_BUNDLE_ENDPOINT \
+    $IPTABLES -A $CHAIN_ALWAYS_ON_OUT -p tcp -d $TITAN_BUILDER_IP --dport $TITAN_BUNDLE_PORT \
         -m conntrack --ctstate NEW -j ACCEPT
 
-    # Return from ALWAYS_ON_OUT
+    # Return from ALWAYS_ON_OUT back to caller (OUTPUT chain -> MODE_SELECTOR_OUT) 
     $IPTABLES -A $CHAIN_ALWAYS_ON_OUT -j RETURN
 
     ###########################################################################
@@ -165,13 +194,14 @@ start_firewall() {
     $IPTABLES -A $CHAIN_MAINTENANCE_IN -p udp --dport $EL_P2P_PORT \
         -m conntrack --ctstate NEW -j ACCEPT
 
-    # Return from MAINTENANCE_IN
+    # Return from MAINTENANCE_IN back to caller (INPUT chain -> END) 
     $IPTABLES -A $CHAIN_MAINTENANCE_IN -j RETURN
 
     ###########################################################################
     # (9) MAINTENANCE_OUT: Outbound rules for Maintenance Mode
     ###########################################################################
     # DNS (UDP/TCP 53)
+    # Note: Searchers will only have DNS in maintenance mode! 
     $IPTABLES -A $CHAIN_MAINTENANCE_OUT -p udp --dport $DNS_PORT \
         -m conntrack --ctstate NEW -j ACCEPT
     $IPTABLES -A $CHAIN_MAINTENANCE_OUT -p tcp --dport $DNS_PORT \
@@ -189,12 +219,13 @@ start_firewall() {
     $IPTABLES -A $CHAIN_MAINTENANCE_OUT -p udp --dport $EL_P2P_PORT \
         -m conntrack --ctstate NEW -j ACCEPT
 
-    # Return from MAINTENANCE_OUT
+    # Return from MAINTENANCE_OUT back to caller (OUTPUT chain -> END) 
     $IPTABLES -A $CHAIN_MAINTENANCE_OUT -j RETURN
 
     ###########################################################################
     # (10) PRODUCTION_IN: Inbound rules for Production Mode
     ###########################################################################
+    # Return from PRODUCTION_IN back to caller (INPUT chain -> END) 
     $IPTABLES -A $CHAIN_PRODUCTION_IN -j RETURN
 
     ###########################################################################
@@ -202,14 +233,14 @@ start_firewall() {
     # IP whitelisted for builder IPs
     ###########################################################################
     # Flashbots state diff
-    $IPTABLES -A $CHAIN_PRODUCTION_OUT -p tcp -d $FLASHBOTS_BUILDER_IP --dport $FLASHBOTS_STATE_DIFF \
+    $IPTABLES -A $CHAIN_PRODUCTION_OUT -p tcp -d $FLASHBOTS_BUILDER_IP --dport $FLASHBOTS_STATE_DIFF_PORT \
         -m conntrack --ctstate NEW -j ACCEPT
 
     # Titan state diff
-    $IPTABLES -A $CHAIN_PRODUCTION_OUT -p tcp -d $TITAN_BUILDER_IP --dport $TITAN_STATE_DIFF \
+    $IPTABLES -A $CHAIN_PRODUCTION_OUT -p tcp -d $TITAN_BUILDER_IP --dport $TITAN_STATE_DIFF_PORT \
         -m conntrack --ctstate NEW -j ACCEPT
 
-    # Return from PRODUCTION_OUT
+    # Return from PRODUCTION_OUT back to caller (OUTPUT chain -> END) 
     $IPTABLES -A $CHAIN_PRODUCTION_OUT -j RETURN
 
     ###########################################################################

--- a/recipes-core/searcher-container/files/searcher-network-init
+++ b/recipes-core/searcher-container/files/searcher-network-init
@@ -173,6 +173,9 @@ start_firewall() {
         -m conntrack --ctstate NEW -j ACCEPT
 
     # Flashbots & Titan builder bundle endpoints (always on)
+    # Security note: This is a side channel.
+    # While the operator will not be able to see the content of the packets, 
+    # they can observe the presence or absence of packets. 
     $IPTABLES -A $CHAIN_ALWAYS_ON_OUT -p tcp -d $FLASHBOTS_BUILDER_IP --dport $FLASHBOTS_BUNDLE_PORT \
         -m conntrack --ctstate NEW -j ACCEPT
     $IPTABLES -A $CHAIN_ALWAYS_ON_OUT -p tcp -d $TITAN_BUILDER_IP --dport $TITAN_BUNDLE_PORT \

--- a/recipes-core/searcher-container/files/searcher-pod-init
+++ b/recipes-core/searcher-container/files/searcher-pod-init
@@ -29,6 +29,7 @@ start_searcher_container() {
     chown -R searcher:searcher /persistent/searcher
 
     # Create directory for searcher logs and set permissions
+    # Fluentbit will need to traverse this directory to ingest the logs
     mkdir -p /persistent/searcher_logs
     chown searcher:searcher /persistent/searcher_logs
     chmod 755 /persistent/searcher_logs

--- a/recipes-core/searcher-container/files/searcher-pod-init
+++ b/recipes-core/searcher-container/files/searcher-pod-init
@@ -28,6 +28,11 @@ start_searcher_container() {
     mkdir -p /persistent/searcher
     chown -R searcher:searcher /persistent/searcher
 
+    # Create directory for searcher logs and set permissions
+    mkdir -p /persistent/searcher_logs
+    chown searcher:searcher /persistent/searcher_logs
+    chmod 755 /persistent/searcher_logs
+
     echo "Starting $NAME..."
     su -s /bin/sh $USER -c "cd ~ && $DAEMON run -d \
         --name $NAME \
@@ -38,7 +43,7 @@ start_searcher_container() {
         -v /etc/searcher_key:/container_auth_keys:ro \
         -v /persistent/searcher:/persistent:rw \
         -v /etc/searcher/ssh_hostkey:/etc/searcher/ssh_hostkey:rw \
-        -v /searcher_logs:/var/log/searcher:rw \
+        -v /persistent/searcher_logs:/var/log/searcher:rw \
         -v /var/volatile/jwt.hex:/secrets/jwt.hex:ro \
         docker.io/library/ubuntu:24.04 \
         /bin/sh -c ' \

--- a/recipes-core/searcher-container/files/searchersh.c
+++ b/recipes-core/searcher-container/files/searchersh.c
@@ -126,9 +126,9 @@ int main(int argc, char *argv[]) {
         }
 
         // Call tail with the specified number of lines, e.g.:
-        // tail -n <arg> /delayed_logs/output.log
-        // If arg = "3", that's tail -n 3 /delayed_logs/output.log
-        execl("/usr/bin/tail", "tail", "-n", arg, "/delayed_logs/output.log", (char *)NULL);
+        // tail -n <arg> /persistent/delayed_logs/output.log
+        // If arg = "3", that's tail -n 3 /persistent/delayed_logs/output.log
+        execl("/usr/bin/tail", "tail", "-n", arg, "/persistent/delayed_logs/output.log", (char *)NULL);
         
         perror("execl failed (logs)");
         free(arg_copy);

--- a/recipes-core/searcher-container/files/searchersh.c
+++ b/recipes-core/searcher-container/files/searchersh.c
@@ -4,7 +4,7 @@
 #include <unistd.h>     // For execl
 #include <ctype.h>      // For isdigit
 
-#define MAX_LINES 10000
+#define MAX_LINES 10000000
 
 // argc is the number of command-line arguments
 // argv is an array of C-strings (character pointers)

--- a/recipes-core/searcher-container/files/searchersh.c
+++ b/recipes-core/searcher-container/files/searchersh.c
@@ -17,34 +17,39 @@ int main(int argc, char *argv[]) {
     }
 
     // Split argv[2] on whitespace into tokens
-    char *command = strtok(arg_copy, " ");
+    char *command = strtok(arg_copy, " "); // return, if non-null is null-terminated, so it can be used in strcmp
+    if (command == NULL) {
+        fprintf(stderr, "No command provided. Valid commands are: toggle, status, logs\n");
+        free(arg_copy);
+        return 1;
+    }
+
+    // Only call strtok again, to possibly get the next token, if command is not NULL
     char *arg = strtok(NULL, " ");  // for example, "3" if argv[2] = "logs 3"
 
-    if (command) {
-        if (strcmp(command, "toggle") == 0) {
-            execl("/usr/bin/sudo", "sudo", "-S", "/usr/bin/toggle", NULL);
-            perror("execl failed (toggle)");
+    if (strcmp(command, "toggle") == 0) {
+        execl("/usr/bin/sudo", "sudo", "-S", "/usr/bin/toggle", NULL);
+        perror("execl failed (toggle)");
+        free(arg_copy);
+        return 1;
+    }
+    else if (strcmp(command, "status") == 0) {
+        execl("/bin/cat", "cat", "/etc/searcher-network.state", NULL);
+        perror("execl failed (status)");
+        free(arg_copy);
+        return 1;
+    }
+    else if (strcmp(command, "logs") == 0) {
+        // If someone wrote "logs 3", 'arg' should be "3"
+        if (arg == NULL) {
+            fprintf(stderr, "Usage: logs <number_of_lines>\n");
             free(arg_copy);
             return 1;
         }
-        else if (strcmp(command, "status") == 0) {
-            execl("/bin/cat", "cat", "/etc/searcher-network.state", NULL);
-            perror("execl failed (status)");
-            free(arg_copy);
-            return 1;
-        }
-        else if (strcmp(command, "logs") == 0) {
-            // If someone wrote "logs 3", 'arg' should be "3"
-            if (!arg) {
-                fprintf(stderr, "Usage: logs <number_of_lines>\n");
-                free(arg_copy);
-                return 1;
-            }
-            execl("/usr/bin/tail", "tail", "-n", arg, "/delayed_logs/output.log", (char *)NULL);
-            perror("execl failed (logs)");
-            free(arg_copy);
-            return 1;
-        }
+        execl("/usr/bin/tail", "tail", "-n", arg, "/delayed_logs/output.log", (char *)NULL);
+        perror("execl failed (logs)");
+        free(arg_copy);
+        return 1;
     }
     
     // If none of the above matched, it's an invalid command

--- a/recipes-core/searcher-container/files/searchersh.c
+++ b/recipes-core/searcher-container/files/searchersh.c
@@ -1,60 +1,142 @@
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
+#include <stdio.h>      // For fprintf, perror
+#include <stdlib.h>     // For exit, malloc/free, strdup, atoi
+#include <string.h>     // For strcmp, strtok
+#include <unistd.h>     // For execl
+#include <ctype.h>      // For isdigit
 
+#define MAX_LINES 10000
+
+// argc is the number of command-line arguments
+// argv is an array of C-strings (character pointers)
 int main(int argc, char *argv[]) {
+
+    // We expect exactly 3 arguments: 
+    // Example: ssh -i ~/.ssh/yocto-searcher -p 8084 searcher@localhost hello 5
+    // argv[0] = 'searchersh'
+    // argv[1] = '-c'
+    // argv[2] = 'hello 5'
+
     if (argc != 3) {
         fprintf(stderr, "Invalid number of arguments\n");
+        return 1; // return error code 1
+    }
+
+    // Verify argv[0] is "searchersh"
+    if (strcmp(argv[0], "searchersh") != 0) {
+        fprintf(stderr, "Error: This program must be invoked as 'searchersh'\n");
         return 1;
     }
 
-    // Make a copy of argv[2], because strtok modifies the string
+    // Verify argv[1] is "-c"
+    if (strcmp(argv[1], "-c") != 0) {
+        fprintf(stderr, "Error: Second argument must be '-c'\n");
+        return 1;
+    }
+
+    // Make a copy of argv[2], because strtok will modify the string
+    // strdup() allocates memory and copies the entire string.
+    // We must free() this memory later.
     char *arg_copy = strdup(argv[2]);
     if (!arg_copy) {
-        perror("strdup failed");
-        return 1;
+        perror("strdup failed"); 
+        return 1; // return error code 1
     }
 
-    // Split argv[2] on whitespace into tokens
-    char *command = strtok(arg_copy, " "); // return, if non-null is null-terminated, so it can be used in strcmp
+    // Use strtok() to split the string in arg_copy by spaces (" ")
+    // strtok modifies the string by inserting '\0' to separate tokens.
+    // 'command' will point to the first token, if it exists.
+    char *command = strtok(arg_copy, " ");
     if (command == NULL) {
+        // If there's no token at all (e.g., empty or whitespace-only string),
+        // we print an error and quit.
         fprintf(stderr, "No command provided. Valid commands are: toggle, status, logs\n");
-        free(arg_copy);
-        return 1;
+        free(arg_copy); // free the memory
+        return 1;       // return error code 1
     }
 
-    // Only call strtok again, to possibly get the next token, if command is not NULL
-    char *arg = strtok(NULL, " ");  // for example, "3" if argv[2] = "logs 3"
+    // If the first token (command) is not NULL, we try to get the next token
+    // 'arg' is needed when the command is "logs <number_of_lines>"
+    // e.g., if argv[2] = "logs 3", then:
+    //   command = "logs"
+    //   arg     = "3"
+    char *arg = strtok(NULL, " ");
 
+    // Compare the first token to see which command we want.
+    // 1) "toggle"
+    // 2) "status"
+    // 3) "logs"
+    // Anything else -> invalid.
+    
+    // If command == "toggle", call /usr/bin/toggle via sudo
     if (strcmp(command, "toggle") == 0) {
-        execl("/usr/bin/sudo", "sudo", "-S", "/usr/bin/toggle", NULL);
+        // execl() replaces the current process with the new program
+        // Arguments to execl:
+        //   1) path to executable: "/usr/bin/sudo"
+        //   2) argv[0] for new program: "sudo"
+        //   3) "-S" accept password from stdin
+        //   4) "/usr/bin/toggle" (the program we actually want to run via sudo)
+        //   5) NULL terminator for argument list
+        // execl("/usr/bin/sudo", "sudo", "-S", "/usr/bin/toggle", NULL);
+        execl("/usr/bin/sudo", "sudo", "/usr/bin/toggle", NULL);
+        
+        // If execl fails, we reach here. perror prints error details.
         perror("execl failed (toggle)");
+        
+        // We must free the copied string before exiting
         free(arg_copy);
         return 1;
     }
+
+    // If command == "status", print the contents of /etc/searcher-network.state
     else if (strcmp(command, "status") == 0) {
+        // runs: cat /etc/searcher-network.state
         execl("/bin/cat", "cat", "/etc/searcher-network.state", NULL);
+        
         perror("execl failed (status)");
         free(arg_copy);
         return 1;
     }
+
+    // If command == "logs", we expect a second token representing number of lines
     else if (strcmp(command, "logs") == 0) {
-        // If someone wrote "logs 3", 'arg' should be "3"
+        // If no second token, user didn't specify how many lines
         if (arg == NULL) {
             fprintf(stderr, "Usage: logs <number_of_lines>\n");
             free(arg_copy);
+            return 1; // return error code 1
+        }
+
+        // 1) Check that 'arg' is strictly numeric
+        for (int i = 0; arg[i] != '\0'; i++) {
+            if (!isdigit((unsigned char)arg[i])) {
+                fprintf(stderr, "Invalid line count (non-digit characters detected): %s\n", arg);
+                free(arg_copy);
+                return 1;
+            }
+        }
+
+        // 2) Convert to int
+        int lines = atoi(arg);
+
+        // 3) Check the range
+        if (lines < 1 || lines > MAX_LINES) {
+            fprintf(stderr, "Number of lines must be between 1 and %d\n", MAX_LINES);
+            free(arg_copy);
             return 1;
         }
+
+        // Call tail with the specified number of lines, e.g.:
+        // tail -n <arg> /delayed_logs/output.log
+        // If arg = "3", that's tail -n 3 /delayed_logs/output.log
         execl("/usr/bin/tail", "tail", "-n", arg, "/delayed_logs/output.log", (char *)NULL);
+        
         perror("execl failed (logs)");
         free(arg_copy);
-        return 1;
+        return 1; // return error code 1
     }
     
-    // If none of the above matched, it's an invalid command
+    // If we reach here, the command didn't match toggle/status/logs
     fprintf(stderr, "Invalid command. Valid commands are: toggle, status, logs\n");
-    free(arg_copy);
-    return 1;
+    free(arg_copy); // Clean up allocated memory
+    return 1;       // Return error code 1
 }
-

--- a/recipes-core/searcher-container/files/toggle
+++ b/recipes-core/searcher-container/files/toggle
@@ -135,13 +135,13 @@ kill_established_connections() {
 configure_mode_rules() {
     local new_mode="$1"
     local old_mode="$2"
-    
-    # 1) Kill all established flows from old mode
-    kill_established_connections "$old_mode"
 
-    # 2) Flush the mode selector so we remove references to the old sub-chain
+    # 1) Flush the mode selector so we remove references to the old sub-chain
     $IPTABLES -F $CHAIN_MODE_SELECTOR_IN
     $IPTABLES -F $CHAIN_MODE_SELECTOR_OUT
+
+    # 2) Kill all established flows from old mode
+    kill_established_connections "$old_mode"
 
     # 3) Depending on new_mode, jump to the matching sub-chains
     case "$new_mode" in

--- a/recipes-core/searcher-container/files/toggle
+++ b/recipes-core/searcher-container/files/toggle
@@ -77,6 +77,7 @@ set_state() {
     echo "$1" > "$STATE_FILE"
 }
 
+# SECURITY: this should only be called from disconnect_from_production()
 write_timestamp() {
     date +%s > "$TIMESTAMP_FILE"
 }
@@ -88,6 +89,7 @@ check_delay() {
     fi
     
     last_stop=$(cat "$TIMESTAMP_FILE")
+    # SECURITY: time can be manipulated by the host
     current_time=$(date +%s)
     delay_seconds=120  # 2 minutes
     
@@ -164,6 +166,7 @@ configure_mode_rules() {
 
 ###############################################################################
 # Container Namespace Rule Verification
+# Check that the searcher-container-netns iptables rules blocking port 9000 are active
 ###############################################################################
 check_searcher_namespace_rules() {
     local cont_name="searcher-container"

--- a/recipes-core/ssh-pubkey-server/files/ssh-pubkey-server-init
+++ b/recipes-core/ssh-pubkey-server/files/ssh-pubkey-server-init
@@ -12,15 +12,16 @@
 DAEMON=/usr/bin/httpserver
 NAME=ssh-pubkey-server
 DESC="SSH Public Key Server"
+SSH_PUBKEY_SERVER_PORT=5001
 KEY_FILE="/etc/searcher/ssh_hostkey/host_key.pub"
-DAEMON_ARGS="--listen-addr=127.0.0.1:8645 --ssh-pubkey-file ${KEY_FILE}"
+DAEMON_ARGS="--listen-addr=127.0.0.1:${SSH_PUBKEY_SERVER_PORT} --ssh-pubkey-file ${KEY_FILE}"
 PIDFILE=/var/run/$NAME.pid
 LOGFILE=/tmp/httpserver.log
 
 PROXY_BIN=/usr/bin/proxy-server
 PROXY_NAME=cvm-reverse-proxy-server
 PROXY_ARGS="--listen-addr=0.0.0.0:8745 \
-            --target-addr=http://localhost:8645 \
+            --target-addr=http://localhost:${SSH_PUBKEY_SERVER_PORT} \
             --server-attestation-type=azure-tdx"
 PROXY_PIDFILE=/var/run/${PROXY_NAME}.pid
 PROXY_LOGFILE=/tmp/${PROXY_NAME}.log


### PR DESCRIPTION
1. hardened and commented searchersh.c
- removed unnecessary -S in toggle execl
- checks that logs x is a non-negative number and <10000
- verifies first two args are "searchersh" and "-c"

2. security comments

3. new logrotate config tailored to searcher needs

4. implement small lua script optimization to table.move

5. lock down lighthouse directory permissions so searchers cannot interfere with lighthouse directory, even if its mounted on persistent

6. change ssh pubkey port number

7. switch order during mode switches: flush first, then kill established connections

8. mount searcher logs to /persistent directory 