### PR TITLE
Trigger Geth Sync Immediately

### DIFF
--- a/recipes-core/lighthouse/init
+++ b/recipes-core/lighthouse/init
@@ -40,6 +40,7 @@ start_lighthouse() {
         --checkpoint-sync-url https://mainnet.checkpoint.sigp.io \
 		--disable-deposit-contract-sync \
 		--datadir "$LIGHTHOUSE_DIR" \
+        --disable-optimistic-finalized-sync \
 		2>&1 | tee ${LOGFILE}"
 }
 


### PR DESCRIPTION
When lighthouse is started without geth, and the searcher's geth node comes online, lighthouse won't trigger sync until 40 minutes after geth is started. 

The reason why is discussed at length here:
https://github.com/ethereum/go-ethereum/issues/27482#issuecomment-1594305329

This flag is officially documented here: 
https://github.com/sigp/lighthouse/blob/bf955c7543dac8911a6f6c334b5b3ca4ef728d9c/book/src/help_bn.md?plain=1#L464