### PR TITLE
Portforward UDP

### DIFF
--- a/recipes-core/searcher-container/files/searcher-pod-init
+++ b/recipes-core/searcher-container/files/searcher-pod-init
@@ -40,7 +40,7 @@ start_searcher_container() {
         -p ${SEARCHER_SSH_PORT}:22 \
         -p ${ENGINE_API_PORT}:${ENGINE_API_PORT} \
         -p ${EL_P2P_PORT}:${EL_P2P_PORT} \
-        -p ${SEARCHER_INPUT_CHANNEL}:${SEARCHER_INPUT_CHANNEL} \
+        -p ${SEARCHER_INPUT_CHANNEL}:${SEARCHER_INPUT_CHANNEL}/udp \
         -v /etc/searcher_key:/container_auth_keys:ro \
         -v /persistent/searcher:/persistent:rw \
         -v /etc/searcher/ssh_hostkey:/etc/searcher/ssh_hostkey:rw \


### PR DESCRIPTION
Explicitly publish UDP on port 27017, by default Podman publishes TCP (not UDP).