### PR TITLE
V2.3: Pectra + Logrotate

### DIFF
--- a/recipes-core/lighthouse/lighthouse_v7.0.1.bb
+++ b/recipes-core/lighthouse/lighthouse_v7.0.1.bb
@@ -1,4 +1,4 @@
 include lighthouse.inc
 
 SRC_URI = "git://github.com/sigp/lighthouse;protocol=https;branch=stable"
-SRCREV = "v5.3.0"
+SRCREV = "v7.0.1"

--- a/recipes-core/logrotate/files/fluentbit-logs.conf
+++ b/recipes-core/logrotate/files/fluentbit-logs.conf
@@ -11,6 +11,6 @@
      missingok
      notifempty
      compress        
-     dateext         # suffix rotated logs with the date
+     dateformat -%Y%m%d-%H%M%S
      maxsize 2G
  }

--- a/recipes-core/searcher-container/files/searcher-pod-init
+++ b/recipes-core/searcher-container/files/searcher-pod-init
@@ -47,6 +47,7 @@ start_searcher_container() {
         -v /etc/searcher/ssh_hostkey:/etc/searcher/ssh_hostkey:rw \
         -v /persistent/searcher_logs:/var/log/searcher:rw \
         -v /var/volatile/jwt.hex:/secrets/jwt.hex:ro \
+        -v /var/log/lighthouse.log:/var/log/lighthouse.log:ro \
         docker.io/library/ubuntu:24.04 \
         /bin/sh -c ' \
             DEBIAN_FRONTEND=noninteractive apt-get update && \


### PR DESCRIPTION
Changes:
- upgrades lighthouse from v5.3.0 to v7.0.1 (pectra!)
- logrotate: set more granular date format to allow rotating log files more than once a day
- mount lighthouse log as read-only for visibility 

Release notes: https://flashbots.notion.site/V2-3-Upgrade-Prague-Logrotate-1e76b4a0d87680f0b8f2c6d864aaa1ab?pvs=74